### PR TITLE
Feature/regexconfig

### DIFF
--- a/dynamic_dynamodb/core/calculators.py
+++ b/dynamic_dynamodb/core/calculators.py
@@ -3,24 +3,26 @@ from dynamic_dynamodb.log_handler import LOGGER as logger
 from dynamic_dynamodb.config_handler import get_table_option
 
 
-def get_min_provisioned_reads(table_name, current_provisioning):
+def get_min_provisioned_reads(table_name, current_provisioning, key_name):
     """ Returns the minimum provisioned reads
 
     :type table_name: str
     :param table_name: Name of the DynamoDB table
     :type current_provisioning: int
     :param current_provisioning: The current provisioning
+    :type key_name: str
+    :param key_name: Name of the key
     :returns: int -- Minimum provisioned reads
     """
-    if get_table_option(table_name, 'min_provisioned_reads'):
+    if get_table_option(key_name, 'min_provisioned_reads'):
         return int(min(
-            get_table_option(table_name, 'min_provisioned_reads'),
+            get_table_option(key_name, 'min_provisioned_reads'),
             (current_provisioning * 2)))
 
     return int(current_provisioning * 2)
 
 
-def get_min_provisioned_writes(table_name, current_provisioning):
+def get_min_provisioned_writes(table_name, current_provisioning, key_name):
     """ Returns the minimum provisioned writes
 
     :type table_name: str
@@ -28,16 +30,18 @@ def get_min_provisioned_writes(table_name, current_provisioning):
     :type current_provisioning: int
     :param current_provisioning: The current provisioning
     :returns: int -- Minimum provisioned writes
+    :type key_name: str
+    :param key_name: Name of the key
     """
-    if get_table_option(table_name, 'min_provisioned_writes'):
+    if get_table_option(key_name, 'min_provisioned_writes'):
         return int(min(
-            get_table_option(table_name, 'min_provisioned_writes'),
+            get_table_option(key_name, 'min_provisioned_writes'),
             (current_provisioning * 2)))
 
     return int(current_provisioning * 2)
 
 
-def decrease_reads_in_percent(table_name, current_provisioning, percent):
+def decrease_reads_in_percent(table_name, current_provisioning, percent, key_name):
     """ Decrease the current_provisioning with percent %
 
     :type table_name: str
@@ -47,6 +51,8 @@ def decrease_reads_in_percent(table_name, current_provisioning, percent):
     :type percent: int
     :param percent: How many percent should we decrease with
     :returns: int -- New provisioning value
+    :type key_name: str
+    :param key_name: Name of the key
     """
     decrease = int(float(current_provisioning)*(float(percent)/100))
     updated_provisioning = current_provisioning - decrease
@@ -56,7 +62,8 @@ def decrease_reads_in_percent(table_name, current_provisioning, percent):
 
     min_provisioned_reads = get_min_provisioned_reads(
         table_name,
-        current_provisioning)
+        current_provisioning,
+        key_name)
 
     if min_provisioned_reads > 0:
         if updated_provisioning < min_provisioned_reads:
@@ -68,7 +75,7 @@ def decrease_reads_in_percent(table_name, current_provisioning, percent):
     return updated_provisioning
 
 
-def increase_reads_in_percent(table_name, current_provisioning, percent):
+def increase_reads_in_percent(table_name, current_provisioning, percent, key_name):
     """ Increase the current_provisioning with percent %
 
     :type table_name: str
@@ -78,6 +85,8 @@ def increase_reads_in_percent(table_name, current_provisioning, percent):
     :type percent: int
     :param percent: How many percent should we increase with
     :returns: int -- New provisioning value
+    :type key_name: str
+    :param key_name: Name of the key
     """
     increase = int(float(current_provisioning)*(float(percent)/100))
     updated_provisioning = current_provisioning + increase
@@ -85,19 +94,19 @@ def increase_reads_in_percent(table_name, current_provisioning, percent):
         'Read provisioning will be increased to {0:d} units'.format(
             updated_provisioning))
 
-    if get_table_option(table_name, 'max_provisioned_reads') > 0:
+    if get_table_option(key_name, 'max_provisioned_reads') > 0:
         if (updated_provisioning >
-            get_table_option(table_name, 'max_provisioned_reads')):
+            get_table_option(key_name, 'max_provisioned_reads')):
 
             logger.info('Reached provisioned reads max limit: {0:d}'.format(
-                int(get_table_option(table_name, 'max_provisioned_reads'))))
+                int(get_table_option(key_name, 'max_provisioned_reads'))))
 
-            return get_table_option(table_name, 'max_provisioned_reads')
+            return get_table_option(key_name, 'max_provisioned_reads')
 
     return updated_provisioning
 
 
-def decrease_writes_in_percent(table_name, current_provisioning, percent):
+def decrease_writes_in_percent(table_name, current_provisioning, percent, key_name):
     """ Decrease the current_provisioning with percent %
 
     :type table_name: str
@@ -107,6 +116,8 @@ def decrease_writes_in_percent(table_name, current_provisioning, percent):
     :type percent: int
     :param percent: How many percent should we decrease with
     :returns: int -- New provisioning value
+    :type key_name: str
+    :param key_name: Name of the key
     """
     decrease = int(float(current_provisioning)*(float(percent)/100))
     updated_provisioning = current_provisioning - decrease
@@ -116,7 +127,8 @@ def decrease_writes_in_percent(table_name, current_provisioning, percent):
 
     min_provisioned_writes = get_min_provisioned_writes(
         table_name,
-        current_provisioning)
+        current_provisioning,
+        key_name)
 
     if min_provisioned_writes > 0:
         if updated_provisioning < min_provisioned_writes:
@@ -128,7 +140,7 @@ def decrease_writes_in_percent(table_name, current_provisioning, percent):
     return updated_provisioning
 
 
-def increase_writes_in_percent(table_name, current_provisioning, percent):
+def increase_writes_in_percent(table_name, current_provisioning, percent, key_name):
     """ Increase the current_provisioning with percent %
 
     :type table_name: str
@@ -138,6 +150,8 @@ def increase_writes_in_percent(table_name, current_provisioning, percent):
     :type percent: int
     :param percent: How many percent should we increase with
     :returns: int -- New provisioning value
+    :type key_name: str
+    :param key_name: Name of the key
     """
     increase = int(float(current_provisioning)*(float(percent)/100))
     updated_provisioning = current_provisioning + increase
@@ -145,19 +159,19 @@ def increase_writes_in_percent(table_name, current_provisioning, percent):
         'Write provisioning will be increased to {0:d} units'.format(
             updated_provisioning))
 
-    if get_table_option(table_name, 'max_provisioned_writes') > 0:
+    if get_table_option(key_name, 'max_provisioned_writes') > 0:
         if (updated_provisioning >
-            get_table_option(table_name, 'max_provisioned_writes')):
+            get_table_option(key_name, 'max_provisioned_writes')):
 
             logger.info('Reached provisioned writes max limit: {0:d}'.format(
-                int(get_table_option(table_name, 'max_provisioned_writes'))))
+                int(get_table_option(key_name, 'max_provisioned_writes'))))
 
-            return get_table_option(table_name, 'max_provisioned_writes')
+            return get_table_option(key_name, 'max_provisioned_writes')
 
     return updated_provisioning
 
 
-def decrease_reads_in_units(table_name, current_provisioning, units):
+def decrease_reads_in_units(table_name, current_provisioning, units, key_name):
     """ Decrease the current_provisioning with units units
 
     :type table_name: str
@@ -167,6 +181,8 @@ def decrease_reads_in_units(table_name, current_provisioning, units):
     :type units: int
     :param units: How many units should we decrease with
     :returns: int -- New provisioning value
+    :type key_name: str
+    :param key_name: Name of the key
     """
     updated_provisioning = int(current_provisioning) - int(units)
     logger.debug(
@@ -175,7 +191,8 @@ def decrease_reads_in_units(table_name, current_provisioning, units):
 
     min_provisioned_reads = get_min_provisioned_reads(
         table_name,
-        current_provisioning)
+        current_provisioning,
+        key_name)
 
     if min_provisioned_reads > 0:
         if updated_provisioning < min_provisioned_reads:
@@ -187,7 +204,7 @@ def decrease_reads_in_units(table_name, current_provisioning, units):
     return updated_provisioning
 
 
-def increase_reads_in_units(table_name, current_provisioning, units):
+def increase_reads_in_units(table_name, current_provisioning, units, key_name):
     """ Increase the current_provisioning with units units
 
     :type table_name: str
@@ -197,25 +214,27 @@ def increase_reads_in_units(table_name, current_provisioning, units):
     :type units: int
     :param units: How many units should we increase with
     :returns: int -- New provisioning value
+    :type key_name: str
+    :param key_name: Name of the key
     """
     updated_provisioning = int(current_provisioning) + int(units)
     logger.debug(
         'Read provisioning will be increased to {0:d} units'.format(
             updated_provisioning))
 
-    if get_table_option(table_name, 'max_provisioned_reads') > 0:
+    if get_table_option(key_name, 'max_provisioned_reads') > 0:
         if (updated_provisioning >
-            get_table_option(table_name, 'max_provisioned_reads')):
+            get_table_option(key_name, 'max_provisioned_reads')):
 
             logger.info('Reached provisioned reads max limit: {0:d}'.format(
-                int(get_table_option(table_name, 'max_provisioned_reads'))))
+                int(get_table_option(key_name, 'max_provisioned_reads'))))
 
-            return get_table_option(table_name, 'max_provisioned_reads')
+            return get_table_option(key_name, 'max_provisioned_reads')
 
     return updated_provisioning
 
 
-def decrease_writes_in_units(table_name, current_provisioning, units):
+def decrease_writes_in_units(table_name, current_provisioning, units, key_name):
     """ Decrease the current_provisioning with units units
 
     :type table_name: str
@@ -225,6 +244,8 @@ def decrease_writes_in_units(table_name, current_provisioning, units):
     :type units: int
     :param units: How many units should we decrease with
     :returns: int -- New provisioning value
+    :type key_name: str
+    :param key_name: Name of the key
     """
     updated_provisioning = int(current_provisioning) - int(units)
     logger.debug(
@@ -233,7 +254,8 @@ def decrease_writes_in_units(table_name, current_provisioning, units):
 
     min_provisioned_writes = get_min_provisioned_writes(
         table_name,
-        current_provisioning)
+        current_provisioning,
+        key_name)
 
     if min_provisioned_writes > 0:
         if updated_provisioning < min_provisioned_writes:
@@ -245,7 +267,7 @@ def decrease_writes_in_units(table_name, current_provisioning, units):
     return updated_provisioning
 
 
-def increase_writes_in_units(table_name, current_provisioning, units):
+def increase_writes_in_units(table_name, current_provisioning, units, key_name):
     """ Increase the current_provisioning with units units
 
     :type table_name: str
@@ -255,19 +277,21 @@ def increase_writes_in_units(table_name, current_provisioning, units):
     :type units: int
     :param units: How many units should we increase with
     :returns: int -- New provisioning value
+    :type key_name: str
+    :param key_name: Name of the key
     """
     updated_provisioning = int(current_provisioning) + int(units)
     logger.debug(
         'Write provisioning will be increased to {0:d} units'.format(
             updated_provisioning))
 
-    if get_table_option(table_name, 'max_provisioned_writes') > 0:
+    if get_table_option(key_name, 'max_provisioned_writes') > 0:
         if (updated_provisioning >
-            get_table_option(table_name, 'max_provisioned_writes')):
+            get_table_option(key_name, 'max_provisioned_writes')):
 
             logger.info('Reached provisioned writes max limit: {0:d}'.format(
-                int(get_table_option(table_name, 'max_provisioned_writes'))))
+                int(get_table_option(key_name, 'max_provisioned_writes'))))
 
-            return get_table_option(table_name, 'max_provisioned_writes')
+            return get_table_option(key_name, 'max_provisioned_writes')
 
     return updated_provisioning

--- a/dynamic_dynamodb/core/dynamodb.py
+++ b/dynamic_dynamodb/core/dynamodb.py
@@ -66,4 +66,21 @@ def get_table(table_name):
 
     return table
 
+def list_table():
+    """ Return list of DynamoDB table available from aws
+
+    :returns: List
+    """
+    try:
+        list_table = DYNAMODB_CONNECTION.list_tables()
+    except DynamoDBResponseError as error:
+        dynamodb_error = error.body['__type'].rsplit('#', 1)[1]
+        if dynamodb_error == 'ResourceNotFoundException':
+            logger.error(
+                'No table not found')
+            sys.exit(1)
+        else:
+            raise
+    return list_table
+
 DYNAMODB_CONNECTION = __get_connection_dynamodb()


### PR DESCRIPTION
Added new feature where configuration can be specified using regex instead of table name, this way we can control multiple table using only one configuration.

ex. specifying [table: my_table*] instead of [table: my_table] in config file will apply configuration to all table name starting with "my_table" string
