### PR TITLE
Fix a few provisioning update issues

### DIFF
--- a/dynamic_dynamodb/aws/dynamodb.py
+++ b/dynamic_dynamodb/aws/dynamodb.py
@@ -279,6 +279,13 @@ def update_table_provisioning(
         if current_writes > writes:
             writes = current_writes
 
+        # Return if we do not need to scale at all
+        if reads == current_reads and writes == current_writes:
+            logger.info(
+                '{0} - No need to scale up reads nor writes'.format(
+                    table_name))
+            return
+
         logger.info(
             '{0} - Retrying to update provisioning, excluding any decreases. '
             'Setting new reads to {1} and new writes to {2}'.format(
@@ -392,8 +399,8 @@ def update_gsi_provisioning(
     :type retry_with_only_increase: bool
     :param retry_with_only_increase: Set to True to ensure only increases
     """
-    current_reads = int(get_provisioned_table_read_units(table_name))
-    current_writes = int(get_provisioned_table_write_units(table_name))
+    current_reads = int(get_provisioned_gsi_read_units(table_name, gsi_name))
+    current_writes = int(get_provisioned_gsi_write_units(table_name, gsi_name))
 
     if retry_with_only_increase:
         # Ensure that we are only doing increases
@@ -402,10 +409,17 @@ def update_gsi_provisioning(
         if current_writes > writes:
             writes = current_writes
 
+        # Return if we do not need to scale at all
+        if reads == current_reads and writes == current_writes:
+            logger.info(
+                '{0} - GSI: {1} - No need to scale up reads nor writes'.format(
+                    table_name, gsi_name))
+            return
+
         logger.info(
-            '{0} - Retrying to update provisioning, excluding any decreases. '
-            'Setting new reads to {1} and new writes to {2}'.format(
-                table_name, reads, writes))
+            '{0} - GSI: {1} - Retrying to update provisioning, excluding any decreases. '
+            'Setting new reads to {2} and new writes to {3}'.format(
+                table_name, gsi_name, reads, writes))
 
     # Check that we are in the right time frame
     m_windows = get_gsi_option(table_key, gsi_key, 'maintenance_windows')

--- a/dynamic_dynamodb/core/gsi.py
+++ b/dynamic_dynamodb/core/gsi.py
@@ -203,10 +203,11 @@ def __ensure_provisioning_reads(
         if consumed_read_units_percent >= num_read_checks_reset_percent:
 
             logger.info(
-                '{0} - Resetting the number of consecutive '
-                'read checks. Reason: Consumed percent {1} is '
-                'greater than reset percent: {2}'.format(
+                '{0} - GSI: {1} - Resetting the number of consecutive '
+                'read checks. Reason: Consumed percent {2} is '
+                'greater than reset percent: {3}'.format(
                     table_name,
+                    gsi_name,
                     consumed_read_units_percent,
                     num_read_checks_reset_percent))
 
@@ -266,9 +267,9 @@ def __ensure_provisioning_reads(
 
             if current_read_units != calculated_provisioning:
                 logger.info(
-                    '{0} - Resetting the number of consecutive '
+                    '{0} - GSI: {1} - Resetting the number of consecutive '
                     'read checks. Reason: scale up event detected'.format(
-                        table_name))
+                        table_name, gsi_name))
                 num_consec_read_checks = 0
                 update_needed = True
                 updated_read_units = calculated_provisioning
@@ -305,8 +306,9 @@ def __ensure_provisioning_reads(
                 'Will not increase writes over gsi-max-provisioned-reads '
                 'limit ({0} writes)'.format(updated_read_units))
 
-    logger.info('{0} - Consecutive read checks {1}/{2}'.format(
+    logger.info('{0} - GSI: {1} - Consecutive read checks {2}/{3}'.format(
         table_name,
+        gsi_name,
         num_consec_read_checks,
         num_read_checks_before_scale_down))
 
@@ -382,10 +384,11 @@ def __ensure_provisioning_writes(
         if consumed_write_units_percent >= num_write_checks_reset_percent:
 
             logger.info(
-                '{0} - Resetting the number of consecutive '
-                'write checks. Reason: Consumed percent {1} is '
-                'greater than reset percent: {2}'.format(
+                '{0} - GSI: {1} - Resetting the number of consecutive '
+                'write checks. Reason: Consumed percent {2} is '
+                'greater than reset percent: {3}'.format(
                     table_name,
+                    gsi_name,
                     consumed_write_units_percent,
                     num_write_checks_reset_percent))
 
@@ -417,9 +420,9 @@ def __ensure_provisioning_writes(
 
         if current_write_units != calculated_provisioning:
             logger.info(
-                '{0} - Resetting the number of consecutive '
+                '{0} - GSI: {1} - Resetting the number of consecutive '
                 'write checks. Reason: scale up event detected'.format(
-                    table_name))
+                    table_name, gsi_name))
             num_consec_write_checks = 0
             update_needed = True
             updated_write_units = calculated_provisioning
@@ -444,9 +447,9 @@ def __ensure_provisioning_writes(
 
             if current_write_units != calculated_provisioning:
                 logger.info(
-                    '{0} - Resetting the number of consecutive '
+                    '{0} - GSI: {1} - Resetting the number of consecutive '
                     'write checks. Reason: scale up event detected'.format(
-                        table_name))
+                        table_name, gsi_name))
                 num_consec_write_checks = 0
                 update_needed = True
                 updated_write_units = calculated_provisioning
@@ -485,8 +488,9 @@ def __ensure_provisioning_writes(
                     gsi_name,
                     updated_write_units))
 
-    logger.info('{0} - Consecutive write checks {1}/{2}'.format(
+    logger.info('{0} - GSI: {1} - Consecutive write checks {2}/{3}'.format(
         table_name,
+        gsi_name,
         num_consec_write_checks,
         num_write_checks_before_scale_down))
 


### PR DESCRIPTION
1. Fix update_gsi_provisioning: should use gsi's current provisioning instead of table's
2. Fix retry_with_only_increase: no need to scale if both writes and reads not changed. o.w. would get "ValidationException: The provisioned throughput for the table will not change." and a waste of call.
3. Fix gsi logs
