### PR TITLE
Removed inconsistent debug printout

### DIFF
--- a/dynamic_dynamodb/aws/dynamodb.py
+++ b/dynamic_dynamodb/aws/dynamodb.py
@@ -552,9 +552,6 @@ def __get_connection_dynamodb(retries=3):
     """
     connected = False
     while not connected:
-        logger.debug('Connecting to DynamoDB in {0}'.format(
-            get_global_option('region')))
-
         if (get_global_option('aws_access_key_id') and
                 get_global_option('aws_secret_access_key')):
             logger.debug(


### PR DESCRIPTION
None of the other services print "Connecting to x in y". Either this is removed or the others get a similar printout. I'll opt for the former for brevity in the log, but perhaps there is value in printing out the region before connecting, in case connection fails and the error message doesn't provide the value of the region.
