### PR TITLE
New feature: Prevent down scaling if there were throttled requests recently

### DIFF
--- a/dynamic_dynamodb/config/__init__.py
+++ b/dynamic_dynamodb/config/__init__.py
@@ -55,6 +55,8 @@ DEFAULT_OPTIONS = {
         'num_write_checks_reset_percent': 0,
         'allow_scaling_down_reads_on_0_percent': False,
         'allow_scaling_down_writes_on_0_percent': False,
+        'prevent_scaling_down_reads_if_throttled_minutes': 0,
+        'prevent_scaling_down_writes_if_throttled_minutes': 0,
         'always_decrease_rw_together': False,
         'maintenance_windows': None,
         'sns_topic_arn': None,
@@ -459,6 +461,17 @@ def __check_table_rules(configuration):
         for option in options:
             if table[option] < 1:
                 print('{0} may not be lower than 1 for table {1}'.format(
+                    option, table_name))
+                sys.exit(1)
+
+        # Ensure non-negative values for throttled requests limits
+        options = [
+            'prevent_scaling_down_reads_if_throttled_minutes',
+            'prevent_scaling_down_writes_if_throttled_minutes'
+        ]
+        for option in options:
+            if table[option] < 0:
+                print('{0} may not be negative for table {1}'.format(
                     option, table_name))
                 sys.exit(1)
 

--- a/dynamic_dynamodb/config/config_file_parser.py
+++ b/dynamic_dynamodb/config/config_file_parser.py
@@ -145,6 +145,18 @@ TABLE_CONFIG_OPTIONS = [
         'type': 'bool'
     },
     {
+        'key': 'prevent_scaling_down_reads_if_throttled_minutes',
+        'option': 'prevent-scaling-down-reads-if-throttled-minutes',
+        'required': False,
+        'type': 'int'
+    },
+    {
+        'key': 'prevent_scaling_down_writes_if_throttled_minutes',
+        'option': 'prevent-scaling-down-writes-if-throttled-minutes',
+        'required': False,
+        'type': 'int'
+    },
+    {
         'key': 'always_decrease_rw_together',
         'option': 'always-decrease-rw-together',
         'required': False,

--- a/dynamic_dynamodb/core/table.py
+++ b/dynamic_dynamodb/core/table.py
@@ -161,6 +161,8 @@ def __ensure_provisioning_reads(table_name, key_name, num_consec_read_checks):
             get_table_option(key_name, 'num_read_checks_before_scale_down')
         num_read_checks_reset_percent = \
             get_table_option(key_name, 'num_read_checks_reset_percent')
+        prevent_scaling_down_reads_if_throttled_minutes = \
+            get_table_option(key_name, 'prevent_scaling_down_reads_if_throttled_minutes')
     except JSONResponseError:
         raise
     except BotoServerError:
@@ -190,6 +192,14 @@ def __ensure_provisioning_reads(table_name, key_name, num_consec_read_checks):
         logger.info(
             '{0} - Scaling down reads is not done when usage is at 0%'.format(
                 table_name))
+
+    elif (prevent_scaling_down_reads_if_throttled_minutes > 0 and
+          table_stats.get_throttled_read_event_count(table_name, prevent_scaling_down_reads_if_throttled_minutes * 60) > 0):
+
+        logger.info(
+            '{0} - Not scaling down reads due to throttled requests in the past {1} minutes.'.format(
+                table_name,
+                prevent_scaling_down_reads_if_throttled_minutes))
 
     elif consumed_read_units_percent >= reads_upper_threshold:
 
@@ -324,6 +334,8 @@ def __ensure_provisioning_writes(
             get_table_option(key_name, 'num_write_checks_before_scale_down')
         num_write_checks_reset_percent = \
             get_table_option(key_name, 'num_write_checks_reset_percent')
+        prevent_scaling_down_writes_if_throttled_minutes = \
+            get_table_option(key_name, 'prevent_scaling_down_writes_if_throttled_minutes')
     except JSONResponseError:
         raise
     except BotoServerError:
@@ -355,6 +367,14 @@ def __ensure_provisioning_writes(
         logger.info(
             '{0} - Scaling down writes is not done when usage is at 0%'.format(
                 table_name))
+
+    elif (prevent_scaling_down_writes_if_throttled_minutes > 0 and
+          table_stats.get_throttled_write_event_count(table_name, prevent_scaling_down_writes_if_throttled_minutes * 60) > 0):
+
+        logger.info(
+            '{0} - Not scaling down writes due to throttled requests in the past {1} minutes.'.format(
+                table_name,
+                prevent_scaling_down_writes_if_throttled_minutes))
 
     elif consumed_write_units_percent >= writes_upper_threshold:
 

--- a/example-dynamic-dynamodb.conf
+++ b/example-dynamic-dynamodb.conf
@@ -120,6 +120,11 @@ max-provisioned-writes: 500
 # of scaling down. Set this to "true" to minimize down scaling.
 #always-decrease-rw-together: true
 
+# Prevent down scaling if there were throttled requests in the last X minutes
+# Default: 0 (0 disables the feature)
+#prevent-scaling-down-reads-if-throttled-minutes: 1440
+#prevent-scaling-down-writes-if-throttled-minutes: 1440
+
 [gsi: ^my_gsi$ table: ^my_table$]
 #
 # Read provisioning configuration


### PR DESCRIPTION
Hi,

I've made some changes to the tool as a measure of precaution for our use case. We have some heavily sharded tables where the ConsumedCapacity metrics don't reflect the actual capacity being used in some of the busier shards. For this reason we wanted to prevent Dynamic DDB from downscaling a table if there were any throttled requests in a certain period of time, ignoring the fact that ConsumedRead/WriteCapacity may be less than or equal to reads/writes_lower_threshold.
I know this is a very specific scenario I'm trying to work around, but if you see any use for this feature/safeguard please consider merging it into the project.

Thanks!
Matías.
