### PR TITLE
Fix URL to download example config file from github

### DIFF
--- a/cloudformation-templates/dynamic-dynamodb.json
+++ b/cloudformation-templates/dynamic-dynamodb.json
@@ -328,7 +328,7 @@
                 "group": "root"
               },
               "/etc/dynamic-dynamodb/example-dynamic-dynamodb.conf": {
-                "source": "https://raw2.github.com/sebdah/dynamic-dynamodb/master/example-dynamic-dynamodb.conf",
+                "source": "https://raw.github.com/sebdah/dynamic-dynamodb/master/example-dynamic-dynamodb.conf",
                 "mode": "000644",
                 "owner": "root",
                 "group": "root"


### PR DESCRIPTION
Cloudformation stack is failing while downloading example config file from location https://raw2.github.com/sebdah/dynamic-dynamodb/master/example-dynamic-dynamodb.conf This is most probably because of change in github in the way it links to raw files.
