### PR TITLE
Does not scale down when one of the provisoned values is already at the low limit

### DIFF
--- a/dynamic_dynamodb/core/gsi.py
+++ b/dynamic_dynamodb/core/gsi.py
@@ -115,7 +115,7 @@ def __calculate_always_decrease_rw_values(
     :param provisioned_writes: Currently provisioned writes
     :returns: (int, int) -- (reads, writes)
     """
-    if read_units < provisioned_reads and write_units < provisioned_writes:
+    if read_units <= provisioned_reads and write_units <= provisioned_writes:
         return (read_units, write_units)
 
     if read_units < provisioned_reads:

--- a/dynamic_dynamodb/core/table.py
+++ b/dynamic_dynamodb/core/table.py
@@ -98,7 +98,7 @@ def __calculate_always_decrease_rw_values(
     :param provisioned_writes: Currently provisioned writes
     :returns: (int, int) -- (reads, writes)
     """
-    if read_units < provisioned_reads and write_units < provisioned_writes:
+    if read_units <= provisioned_reads and write_units <= provisioned_writes:
         return (read_units, write_units)
 
     if read_units < provisioned_reads:


### PR DESCRIPTION
When always-decrease-rw-together is true if either one is at the lower limit it will not scale down the other value.

Ex. Writes is already at lower specified limit 5; reads is at 13 but can be lowered to 5 (its bellow the threshould)

The application keeps logging the message "Changing provisioning to 7 read units and 5 write units" but later logs "Reads could be decreased, but we are waiting for writes to get lower than the threshold before scaling down" instead of scaling down"

We need to scale down in this condition!

This looks related to #133 &  #142?! 