### PR TITLE
Match each table to at most one config section

### DIFF
--- a/docs/example_configuration.rst
+++ b/docs/example_configuration.rst
@@ -225,7 +225,7 @@ This is a full example of a Dynamic DynamoDB configuration file.
     # of scaling down. Set this to "true" to minimize down scaling.
     #always-decrease-rw-together: true
 
-Note: The configuration of tables support regular expressions so you could write ``[table: log_.* ]`` if you want to target multiple tables with one config section.
+Note: The configuration of tables support regular expressions so you could write ``[table: log_.* ]`` if you want to target multiple tables with one config section, however if a table name matches the regex of more than one section, only the first match will be used.  (This will let you set a ``[table: .*]`` section at the end as a catchall.)
 
 
 Example ``logging.conf``

--- a/dynamic_dynamodb/aws/dynamodb.py
+++ b/dynamic_dynamodb/aws/dynamodb.py
@@ -36,19 +36,18 @@ def get_tables_and_gsis():
                         table_instance.table_name, key_name))
 
                     # Notify users about regexps that match multiple tables
-                    for key, value in table_names:
-                        if key == table_instance.table_name:
-                            logger.warning(
-                                'Table {0} matches multiple regexps in '
-                                'the configuration'.format(
-                                    table_instance.table_name))
-
-                    table_names.add(
-                        (
-                            table_instance.table_name,
-                            key_name
-                        ))
-                    not_used_tables.discard(key_name)
+                    if table_instance.table_name in [x[0] for x in table_names]:
+                        logger.warning(
+                            'Table {0} matches more than one regexp in config, '
+                            'skipping this match: "{1}"'.format(
+                                table_instance.table_name, key_name))
+                    else:
+                        table_names.add(
+                            (
+                                table_instance.table_name,
+                                key_name
+                            ))
+                        not_used_tables.discard(key_name)
                 else:
                     logger.debug(
                         "Table {0} did not match with config key {1}".format(

--- a/dynamic_dynamodb/config/__init__.py
+++ b/dynamic_dynamodb/config/__init__.py
@@ -4,6 +4,11 @@ import sys
 from dynamic_dynamodb.config import config_file_parser
 from dynamic_dynamodb.config import command_line_parser
 
+try:
+    from collections import OrderedDict as ordereddict
+except ImportError:
+    import ordereddict
+
 DEFAULT_OPTIONS = {
     'global': {
         # Command line only
@@ -119,7 +124,7 @@ def get_configuration():
     configuration = {
         'global': {},
         'logging': {},
-        'tables': {}
+        'tables': ordereddict()
     }
 
     # Read the command line options
@@ -179,11 +184,11 @@ def __get_cmd_table_options(cmd_line_options):
 def __get_config_table_options(conf_file_options):
     """ Get all table options from the config file
 
-    :type conf_file_options: dict
+    :type conf_file_options: ordereddict
     :param conf_file_options: Dictionary with all config file options
-    :returns: dict -- E.g. {'table_name': {}}
+    :returns: ordereddict -- E.g. {'table_name': {}}
     """
-    options = {}
+    options = ordereddict()
 
     if not conf_file_options:
         return options

--- a/dynamic_dynamodb/config/config_file_parser.py
+++ b/dynamic_dynamodb/config/config_file_parser.py
@@ -5,6 +5,11 @@ import os.path
 import ConfigParser
 from copy import deepcopy
 
+try:
+    from collections import OrderedDict as ordereddict
+except ImportError:
+    import ordereddict
+
 TABLE_CONFIG_OPTIONS = [
     {
         'key': 'enable_reads_autoscaling',
@@ -407,7 +412,7 @@ def parse(config_path):
     #
     # Handle [table: ]
     #
-    table_config = {'tables': {}}
+    table_config = {'tables': ordereddict()}
 
     # Find the first table definition
     found_table = False
@@ -446,10 +451,10 @@ def parse(config_path):
             table_config['tables'][table_key]['gsis'] = {}
 
         table_config['tables'][table_key]['gsis'][gsi_key] = \
-            dict(default_options.items() + __parse_options(
+            ordereddict(default_options.items() + __parse_options(
                 config_file, current_section, TABLE_CONFIG_OPTIONS).items())
 
-    return dict(
+    return ordereddict(
         global_config.items() +
         logging_config.items() +
         table_config.items())

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,24 @@
 """ Setup script for PyPI """
 import os
+import sys
 from setuptools import setup
 from ConfigParser import SafeConfigParser
 
 settings = SafeConfigParser()
 settings.read(os.path.realpath('dynamic_dynamodb/dynamic-dynamodb.conf'))
 
+
+def return_requires():
+    install_requires = [
+        'boto >= 2.29.1',
+        'requests >= 0.14.1',
+        'logutils >= 0.3.3',
+        'retrying >= 1.3.3',
+        'ordereddict >= 1.1'
+    ],
+    if sys.version_info < (2, 7):
+        install_requires.append('ordereddict >= 1.1')
+    return install_requires
 
 setup(
     name='dynamic-dynamodb',
@@ -21,12 +34,7 @@ setup(
     scripts=['dynamic-dynamodb'],
     include_package_data=True,
     zip_safe=False,
-    install_requires=[
-        'boto >= 2.29.1',
-        'requests >= 0.14.1',
-        'logutils >= 0.3.3',
-        'retrying >= 1.3.3'
-    ],
+    install_requires=return_requires(),
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,7 @@ def return_requires():
         'boto >= 2.29.1',
         'requests >= 0.14.1',
         'logutils >= 0.3.3',
-        'retrying >= 1.3.3',
-        'ordereddict >= 1.1'
+        'retrying >= 1.3.3'
     ],
     if sys.version_info < (2, 7):
         install_requires.append('ordereddict >= 1.1')


### PR DESCRIPTION
In re: https://github.com/sebdah/dynamic-dynamodb/issues/250

- filter duplicate table entries out of table_names in get_tables_and_gsis()
- use collections.OrderedDict to preserve the order of table
  configuration sections as we parse the config file
- use ordereddict from PyPi if we are using python < 2.7