### PR TITLE
Fix installation on Python < 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def return_requires():
         'requests >= 0.14.1',
         'logutils >= 0.3.3',
         'retrying >= 1.3.3'
-    ],
+    ]
     if sys.version_info < (2, 7):
         install_requires.append('ordereddict >= 1.1')
     return install_requires


### PR DESCRIPTION
When the install_requires array was moved, a erroneous trailing comma was left, turning it into a tuple which cannot be appended to.  Removing the comma allows installation on Python 2.6 which is what CloudFormation uses.