### PR TITLE
Allow configurable lookback period instead of the hardcoded 5 minute one

### DIFF
--- a/docs/configuration_options.rst
+++ b/docs/configuration_options.rst
@@ -41,8 +41,6 @@ Table configuration
 
 Important note: The table name is treated as a regular expression. That means that ``my_table`` also will match ``my_table2``, unless you express it as a valid regular expression; ``^my_table$``. This feature enables you to easily configure many tables or tables with dynamic names.
 
-Please note also that DynamoDB writes CloudWatch data every 5 minutes, thus ``reads/writes-upper/lower-threshold`` and ``throttled-reads/writes-upper-threshold`` is counted over 5 minute intervals.
-
 =============================================== ========= =========================== ==========================================
 Option                                          Type      Default                     Comment
 =============================================== ========= =========================== ==========================================
@@ -93,7 +91,8 @@ increase-throttled-by-provisioned-writes-scale  ``dict``                        
                                                                                       Detailed information on the scale dict can be found `here <http://dynamic-dynamodb.readthedocs.org/en/latest/granular_scaling.html>`__.
 increase-writes-unit                            ``str``   ``percent``                 Set if we should scale up in ``units`` or ``percent``
 increase-writes-with                            ``int``   50                          Number of ``units`` or ``percent`` we should scale up the write provisioning with. Choose entity with ``increase-writes-unit``.
-lookback-window-start                           ``int``   15                          Dynamic DynamoDB fetches data from CloudWatch in a window that streches between ``now()-15`` and ``now()-10`` minutes. If you want to look at slightly newer data, change this value. Please note that it might not be set to less than 5 minutes (as CloudWatch data for DynamoDB is updated every 5 minutes).
+lookback-window-start                           ``int``   15                          Dynamic DynamoDB fetches data from CloudWatch in a window that streches between ``now()-15`` and ``now()-10`` minutes. If you want to look at slightly newer data, change this value. Please note that it might not be set to less than 1 minute (as CloudWatch data for DynamoDB is updated every minute).
+lookback-period                                 ``int``   5                           Changes the duration of CloudWatch data to look at. For example, instead of looking at ``now()-15`` to ``now()-10``, you can look at ``now()-15`` to ``now()-14``
 maintenance-windows                             ``str``                               Force Dynamic DynamoDB to operate within maintenance windows. E.g. ``22:00-23:59,00:00-06:00``
 max-provisioned-reads                           ``int``                               Maximum number of provisioned reads for the table
 max-provisioned-writes                          ``int``                               Maximum number of provisioned writes for the table
@@ -128,8 +127,6 @@ Global secondary index configuration
 Important note: Both the GSI name and the table name is treated as regular expressions. That means that ``my_gsi`` also will match ``my_gsi``, unless you express it as a valid regular expression; ``^my_gsi$``. This feature enables you to easily configure many GSIs with one configuration section.
 
 The ``table:`` section after ``gsi:`` **must** match with an existing ``table:`` section.
-
-Please note also that DynamoDB writes CloudWatch data every 5 minutes, thus ``reads/writes-upper/lower-threshold`` and ``throttled-reads/writes-upper-threshold`` is counted over 5 minute intervals.
 
 =============================================== ========= =========================== ==========================================
 Option                                          Type      Default                     Comment

--- a/dynamic_dynamodb/config/__init__.py
+++ b/dynamic_dynamodb/config/__init__.py
@@ -70,6 +70,7 @@ DEFAULT_OPTIONS = {
         'allow_scaling_down_writes_on_0_percent': False,
         'always_decrease_rw_together': False,
         'lookback_window_start': 15,
+        'lookback_period': 5,
         'maintenance_windows': None,
         'sns_topic_arn': None,
         'sns_message_types': [],
@@ -125,6 +126,7 @@ DEFAULT_OPTIONS = {
         'allow_scaling_down_writes_on_0_percent': False,
         'always_decrease_rw_together': False,
         'lookback_window_start': 15,
+        'lookback_period': 5,
         'maintenance_windows': None,
         'sns_topic_arn': None,
         'sns_message_types': [],
@@ -405,10 +407,10 @@ def __check_gsi_rules(configuration):
                 sys.exit(1)
 
             # Check lookback-window start
-            if gsi['lookback_window_start'] < 5:
+            if gsi['lookback_window_start'] < 1:
                 print(
-                    'lookback-window-start must be a value higher than 5, '
-                    'as DynamoDB sends CloudWatch data every 5 minutes')
+                    'lookback-window-start must be a value higher than 1, '
+                    'as DynamoDB sends CloudWatch data every minute')
                 sys.exit(1)
 
             # Check sns-message-types
@@ -567,10 +569,10 @@ def __check_table_rules(configuration):
             sys.exit(1)
 
         # Check lookback-window start
-        if table['lookback_window_start'] < 5:
+        if table['lookback_window_start'] < 1:
             print(
-                'lookback-window-start must be a value higher than 5, '
-                'as DynamoDB sends CloudWatch data every 5 minutes')
+                'lookback-window-start must be a value higher than 1, '
+                'as DynamoDB sends CloudWatch data every minute')
             sys.exit(1)
 
         # Check sns-message-types

--- a/dynamic_dynamodb/config/config_file_parser.py
+++ b/dynamic_dynamodb/config/config_file_parser.py
@@ -247,6 +247,12 @@ TABLE_CONFIG_OPTIONS = [
         'type': 'int'
     },
     {
+        'key': 'lookback_period',
+        'option': 'lookback-period',
+        'required': False,
+        'type': 'int'
+    },
+    {
         'key': 'increase_throttled_by_provisioned_reads_unit',
         'option': 'increase-throttled-by-provisioned-reads-unit',
         'required': False,

--- a/dynamic_dynamodb/core/gsi.py
+++ b/dynamic_dynamodb/core/gsi.py
@@ -166,20 +166,22 @@ def __ensure_provisioning_reads(
     try:
         lookback_window_start = get_gsi_option(
             table_key, gsi_key, 'lookback_window_start')
+        lookback_period = get_gsi_option(
+            table_key, gsi_key, 'lookback_period')
         current_read_units = dynamodb.get_provisioned_gsi_read_units(
             table_name, gsi_name)
         consumed_read_units_percent = \
             gsi_stats.get_consumed_read_units_percent(
-                table_name, gsi_name, lookback_window_start)
+                table_name, gsi_name, lookback_window_start, lookback_period)
         throttled_read_count = \
             gsi_stats.get_throttled_read_event_count(
-                table_name, gsi_name, lookback_window_start)
+                table_name, gsi_name, lookback_window_start, lookback_period)
         throttled_by_provisioned_read_percent = \
             gsi_stats.get_throttled_by_provisioned_read_event_percent(
-                table_name, gsi_name, lookback_window_start)
+                table_name, gsi_name, lookback_window_start, lookback_period)
         throttled_by_consumed_read_percent = \
             gsi_stats.get_throttled_by_consumed_read_percent(
-                table_name, gsi_name, lookback_window_start)
+                table_name, gsi_name, lookback_window_start, lookback_period)
         reads_upper_threshold = \
             get_gsi_option(table_key, gsi_key, 'reads_upper_threshold')
         reads_lower_threshold = \
@@ -559,20 +561,22 @@ def __ensure_provisioning_writes(
     try:
         lookback_window_start = get_gsi_option(
             table_key, gsi_key, 'lookback_window_start')
+        lookback_period = get_gsi_option(
+            table_key, gsi_key, 'lookback_period')
         current_write_units = dynamodb.get_provisioned_gsi_write_units(
             table_name, gsi_name)
         consumed_write_units_percent = \
             gsi_stats.get_consumed_write_units_percent(
-                table_name, gsi_name, lookback_window_start)
+                table_name, gsi_name, lookback_window_start, lookback_period)
         throttled_write_count = \
             gsi_stats.get_throttled_write_event_count(
-                table_name, gsi_name, lookback_window_start)
+                table_name, gsi_name, lookback_window_start, lookback_period)
         throttled_by_provisioned_write_percent = \
             gsi_stats.get_throttled_by_provisioned_write_event_percent(
-                table_name, gsi_name, lookback_window_start)
+                table_name, gsi_name, lookback_window_start, lookback_period)
         throttled_by_consumed_write_percent = \
             gsi_stats.get_throttled_by_consumed_write_percent(
-                table_name, gsi_name, lookback_window_start)
+                table_name, gsi_name, lookback_window_start, lookback_period)
         writes_upper_threshold = \
             get_gsi_option(table_key, gsi_key, 'writes_upper_threshold')
         writes_lower_threshold = \
@@ -996,10 +1000,12 @@ def __ensure_provisioning_alarm(table_name, table_key, gsi_name, gsi_key):
     """
     lookback_window_start = get_gsi_option(
         table_key, gsi_key, 'lookback_window_start')
+    lookback_period = get_gsi_option(
+        table_key, gsi_key, 'lookback_period')
     consumed_read_units_percent = gsi_stats.get_consumed_read_units_percent(
-        table_name, gsi_name, lookback_window_start)
+        table_name, gsi_name, lookback_window_start, lookback_period)
     consumed_write_units_percent = gsi_stats.get_consumed_write_units_percent(
-        table_name, gsi_name, lookback_window_start)
+        table_name, gsi_name, lookback_window_start, lookback_period)
 
     reads_upper_alarm_threshold = \
         get_gsi_option(table_key, gsi_key, 'reads-upper-alarm-threshold')

--- a/dynamic_dynamodb/core/table.py
+++ b/dynamic_dynamodb/core/table.py
@@ -141,20 +141,21 @@ def __ensure_provisioning_reads(table_name, key_name, num_consec_read_checks):
     try:
         lookback_window_start = get_table_option(
             key_name, 'lookback_window_start')
+        lookback_period = get_table_option(key_name, 'lookback_period')
         current_read_units = dynamodb.get_provisioned_table_read_units(
             table_name)
         consumed_read_units_percent = \
             table_stats.get_consumed_read_units_percent(
-                table_name, lookback_window_start)
+                table_name, lookback_window_start, lookback_period)
         throttled_read_count = \
             table_stats.get_throttled_read_event_count(
-                table_name, lookback_window_start)
+                table_name, lookback_window_start, lookback_period)
         throttled_by_provisioned_read_percent = \
             table_stats.get_throttled_by_provisioned_read_event_percent(
-                table_name, lookback_window_start)
+                table_name, lookback_window_start, lookback_period)
         throttled_by_consumed_read_percent = \
             table_stats.get_throttled_by_consumed_read_percent(
-                table_name, lookback_window_start)
+                table_name, lookback_window_start, lookback_period)
         reads_upper_threshold = \
             get_table_option(key_name, 'reads_upper_threshold')
         reads_lower_threshold = \
@@ -470,20 +471,21 @@ def __ensure_provisioning_writes(
     try:
         lookback_window_start = get_table_option(
             key_name, 'lookback_window_start')
+        lookback_period = get_table_option(key_name, 'lookback_period')
         current_write_units = dynamodb.get_provisioned_table_write_units(
             table_name)
         consumed_write_units_percent = \
             table_stats.get_consumed_write_units_percent(
-                table_name, lookback_window_start)
+                table_name, lookback_window_start, lookback_period)
         throttled_write_count = \
             table_stats.get_throttled_write_event_count(
-                table_name, lookback_window_start)
+                table_name, lookback_window_start, lookback_period)
         throttled_by_provisioned_write_percent = \
             table_stats.get_throttled_by_provisioned_write_event_percent(
-                table_name, lookback_window_start)
+                table_name, lookback_window_start, lookback_period)
         throttled_by_consumed_write_percent = \
             table_stats.get_throttled_by_consumed_write_percent(
-                table_name, lookback_window_start)
+                table_name, lookback_window_start, lookback_period)
         writes_upper_threshold = \
             get_table_option(key_name, 'writes_upper_threshold')
         writes_lower_threshold = \
@@ -842,10 +844,11 @@ def __ensure_provisioning_alarm(table_name, key_name):
     """
     lookback_window_start = get_table_option(
         key_name, 'lookback_window_start')
+    lookback_period = get_table_option(key_name, 'lookback_period')
     consumed_read_units_percent = table_stats.get_consumed_read_units_percent(
-        table_name, lookback_window_start)
+        table_name, lookback_window_start, lookback_period)
     consumed_write_units_percent = table_stats.get_consumed_write_units_percent(
-        table_name, lookback_window_start)
+        table_name, lookback_window_start, lookback_period)
 
     reads_upper_alarm_threshold = \
         get_table_option(key_name, 'reads-upper-alarm-threshold')

--- a/dynamic_dynamodb/statistics/table.py
+++ b/dynamic_dynamodb/statistics/table.py
@@ -20,6 +20,8 @@ def get_consumed_read_units_percent(table_name, lookback_window_start=15,
     :param table_name: Name of the DynamoDB table
     :type lookback_window_start: int
     :param lookback_window_start: Relative start time for the CloudWatch metric
+    :type lookback_period: int
+    :param lookback_period: Number of minutes to look at
     :returns: float -- Number of consumed reads as a percentage of provisioned reads
     """
     try:
@@ -55,6 +57,8 @@ def get_throttled_read_event_count(table_name, lookback_window_start=15,
     :param table_name: Name of the DynamoDB table
     :type lookback_window_start: int
     :param lookback_window_start: Relative start time for the CloudWatch metric
+    :type lookback_period: int
+    :param lookback_period: Number of minutes to look at
     :returns: int -- Number of throttled read events during the time period
     """
     try:
@@ -83,6 +87,8 @@ def get_throttled_by_provisioned_read_event_percent(table_name,
     :param table_name: Name of the DynamoDB table
     :type lookback_window_start: int
     :param lookback_window_start: Relative start time for the CloudWatch metric
+    :type lookback_period: int
+    :param lookback_period: Number of minutes to look at
     :returns: float -- Percent of throttled read events by provisioning
     """
     try:
@@ -118,6 +124,8 @@ def get_throttled_by_consumed_read_percent(table_name, lookback_window_start=15,
     :param table_name: Name of the DynamoDB table
     :type lookback_window_start: int
     :param lookback_window_start: Relative start time for the CloudWatch metric
+    :type lookback_period: int
+    :param lookback_period: Number of minutes to look at
     :returns: float -- Percent of throttled read events by consumption
     """
 
@@ -152,6 +160,8 @@ def get_consumed_write_units_percent(table_name, lookback_window_start=15,
     :param table_name: Name of the DynamoDB table
     :type lookback_window_start: int
     :param lookback_window_start: Relative start time for the CloudWatch metric
+    :type lookback_period: int
+    :param lookback_period: Number of minutes to look at
     :returns: float -- Number of consumed writes as a percentage of provisioned writes
     """
     try:
@@ -188,6 +198,8 @@ def get_throttled_write_event_count(table_name,
     :param table_name: Name of the DynamoDB table
     :type lookback_window_start: int
     :param lookback_window_start: Relative start time for the CloudWatch metric
+    :type lookback_period: int
+    :param lookback_period: Number of minutes to look at
     :returns: int -- Number of throttled write events during the time period
     """
     try:
@@ -216,6 +228,8 @@ def get_throttled_by_provisioned_write_event_percent(table_name,
     :param table_name: Name of the DynamoDB table
     :type lookback_window_start: int
     :param lookback_window_start: Relative start time for the CloudWatch metric
+    :type lookback_period: int
+    :param lookback_period: Number of minutes to look at
     :returns: float -- Percent of throttled write events by provisioning
     """
     try:
@@ -252,6 +266,8 @@ def get_throttled_by_consumed_write_percent(table_name,
     :param table_name: Name of the DynamoDB table
     :type lookback_window_start: int
     :param lookback_window_start: Relative start time for the CloudWatch metric
+    :type lookback_period: int
+    :param lookback_period: Number of minutes to look at
     :returns: float -- Percent of throttled write events by consumption
     """
 

--- a/dynamic_dynamodb/statistics/table.py
+++ b/dynamic_dynamodb/statistics/table.py
@@ -12,7 +12,8 @@ from dynamic_dynamodb.aws.cloudwatch import (
     CLOUDWATCH_CONNECTION as cloudwatch_connection)
 
 
-def get_consumed_read_units_percent(table_name, lookback_window_start=15):
+def get_consumed_read_units_percent(table_name, lookback_window_start=15,
+                                    lookback_period=5):
     """ Returns the number of consumed read units in percent
 
     :type table_name: str
@@ -23,18 +24,21 @@ def get_consumed_read_units_percent(table_name, lookback_window_start=15):
     """
     try:
         metrics = __get_aws_metric(
-            table_name, lookback_window_start, 'ConsumedReadCapacityUnits')
+            table_name, lookback_window_start, lookback_period,
+            'ConsumedReadCapacityUnits')
     except BotoServerError:
         raise
 
     if metrics:
-        consumed_read_units = (float(metrics[0]['Sum'])/float(300))
+        lookback_seconds = lookback_period * 60
+        consumed_read_units = (
+            float(metrics[0]['Sum']) / float(lookback_seconds))
     else:
         consumed_read_units = 0
 
     try:
-        consumed_read_units_percent = (float(consumed_read_units) /
-                float(dynamodb.get_provisioned_table_read_units(table_name)) * 100)
+        consumed_read_units_percent = (float(consumed_read_units) / float(
+            dynamodb.get_provisioned_table_read_units(table_name)) * 100)
     except JSONResponseError:
         raise
 
@@ -43,7 +47,8 @@ def get_consumed_read_units_percent(table_name, lookback_window_start=15):
     return consumed_read_units_percent
 
 
-def get_throttled_read_event_count(table_name, lookback_window_start=15):
+def get_throttled_read_event_count(table_name, lookback_window_start=15,
+                                   lookback_period=5):
     """ Returns the number of throttled read events during a given time frame
 
     :type table_name: str
@@ -54,7 +59,8 @@ def get_throttled_read_event_count(table_name, lookback_window_start=15):
     """
     try:
         metrics = __get_aws_metric(
-            table_name, lookback_window_start, 'ReadThrottleEvents')
+            table_name, lookback_window_start, lookback_period,
+            'ReadThrottleEvents')
     except BotoServerError:
         raise
 
@@ -68,7 +74,9 @@ def get_throttled_read_event_count(table_name, lookback_window_start=15):
     return throttled_read_count
 
 
-def get_throttled_by_provisioned_read_event_percent(table_name, lookback_window_start=15):
+def get_throttled_by_provisioned_read_event_percent(table_name,
+                                                    lookback_window_start=15,
+                                                    lookback_period=5):
     """ Returns the number of throttled read events in percent
 
     :type table_name: str
@@ -79,18 +87,21 @@ def get_throttled_by_provisioned_read_event_percent(table_name, lookback_window_
     """
     try:
         metrics = __get_aws_metric(
-            table_name, lookback_window_start, 'ReadThrottleEvents')
+            table_name, lookback_window_start, lookback_period,
+            'ReadThrottleEvents')
     except BotoServerError:
         raise
 
     if metrics:
-        throttled_read_events = float(metrics[0]['Sum'])/float(300)
+        throttled_read_events = float(metrics[0]['Sum']) / float(
+            lookback_period)
     else:
         throttled_read_events = 0
 
-    try: throttled_by_provisioned_read_percent = (float(throttled_read_events) /
-                                                float(dynamodb.get_provisioned_table_read_units(table_name)) *
-                                                100)
+    try:
+        throttled_by_provisioned_read_percent = (
+            float(throttled_read_events) / float(
+                dynamodb.get_provisioned_table_read_units(table_name)) * 100)
     except JSONResponseError:
         raise
 
@@ -99,7 +110,8 @@ def get_throttled_by_provisioned_read_event_percent(table_name, lookback_window_
     return throttled_by_provisioned_read_percent
 
 
-def get_throttled_by_consumed_read_percent(table_name, lookback_window_start=15):
+def get_throttled_by_consumed_read_percent(table_name, lookback_window_start=15,
+                                           lookback_period=5):
     """ Returns the number of throttled read events in percent of consumption
 
     :type table_name: str
@@ -111,15 +123,19 @@ def get_throttled_by_consumed_read_percent(table_name, lookback_window_start=15)
 
     try:
         metrics1 = __get_aws_metric(
-            table_name, lookback_window_start, 'ConsumedReadCapacityUnits')
+            table_name, lookback_window_start, lookback_period,
+            'ConsumedReadCapacityUnits')
         metrics2 = __get_aws_metric(
-            table_name, lookback_window_start, 'ReadThrottleEvents')
+            table_name, lookback_window_start, lookback_period,
+            'ReadThrottleEvents')
     except BotoServerError:
         raise
 
     if metrics1 and metrics2:
-        throttled_by_consumed_read_percent = (((float(metrics2[0]['Sum'])/float(300)) /
-                                               (float(metrics1[0]['Sum'])/float(300))) * 100)
+        lookback_seconds = lookback_period * 60
+        throttled_by_consumed_read_percent = (
+            ((float(metrics2[0]['Sum']) / float(lookback_seconds)) /
+             (float(metrics1[0]['Sum']) / float(lookback_seconds))) * 100)
     else:
         throttled_by_consumed_read_percent = 0
 
@@ -128,7 +144,8 @@ def get_throttled_by_consumed_read_percent(table_name, lookback_window_start=15)
     return throttled_by_consumed_read_percent
 
 
-def get_consumed_write_units_percent(table_name, lookback_window_start=15):
+def get_consumed_write_units_percent(table_name, lookback_window_start=15,
+                                     lookback_period=5):
     """ Returns the number of consumed write units in percent
 
     :type table_name: str
@@ -139,18 +156,21 @@ def get_consumed_write_units_percent(table_name, lookback_window_start=15):
     """
     try:
         metrics = __get_aws_metric(
-            table_name, lookback_window_start, 'ConsumedWriteCapacityUnits')
+            table_name, lookback_window_start, lookback_period,
+            'ConsumedWriteCapacityUnits')
     except BotoServerError:
         raise
 
     if metrics:
-        consumed_write_units = (float(metrics[0]['Sum'])/float(300))
+        lookback_seconds = lookback_period * 60
+        consumed_write_units = (
+            float(metrics[0]['Sum']) / float(lookback_seconds))
     else:
         consumed_write_units = 0
 
     try:
-        consumed_write_units_percent = (float(consumed_write_units) /
-                float(dynamodb.get_provisioned_table_write_units(table_name)) * 100)
+        consumed_write_units_percent = (float(consumed_write_units) / float(
+            dynamodb.get_provisioned_table_write_units(table_name)) * 100)
     except JSONResponseError:
         raise
 
@@ -159,7 +179,9 @@ def get_consumed_write_units_percent(table_name, lookback_window_start=15):
     return consumed_write_units_percent
 
 
-def get_throttled_write_event_count(table_name, lookback_window_start=15):
+def get_throttled_write_event_count(table_name,
+                                    lookback_window_start=15,
+                                    lookback_period=5):
     """ Returns the number of throttled write events during a given time frame
 
     :type table_name: str
@@ -170,7 +192,8 @@ def get_throttled_write_event_count(table_name, lookback_window_start=15):
     """
     try:
         metrics = __get_aws_metric(
-            table_name, lookback_window_start, 'WriteThrottleEvents')
+            table_name, lookback_window_start, lookback_period,
+            'WriteThrottleEvents')
     except BotoServerError:
         raise
 
@@ -184,7 +207,9 @@ def get_throttled_write_event_count(table_name, lookback_window_start=15):
     return throttled_write_count
 
 
-def get_throttled_by_provisioned_write_event_percent(table_name, lookback_window_start=15):
+def get_throttled_by_provisioned_write_event_percent(table_name,
+                                                     lookback_window_start=15,
+                                                     lookback_period=5):
     """ Returns the number of throttled write events during a given time frame
 
     :type table_name: str
@@ -195,17 +220,21 @@ def get_throttled_by_provisioned_write_event_percent(table_name, lookback_window
     """
     try:
         metrics = __get_aws_metric(
-            table_name, lookback_window_start, 'WriteThrottleEvents')
+            table_name, lookback_window_start, lookback_period,
+            'WriteThrottleEvents')
     except BotoServerError:
         raise
 
     if metrics:
-        throttled_write_events = float(metrics[0]['Sum'])/float(300)
+        throttled_write_events = float(metrics[0]['Sum']) / float(
+            lookback_period)
     else:
         throttled_write_events = 0
 
-    try: throttled_by_provisioned_write_percent = (float(throttled_write_events) /
-                                                   float(dynamodb.get_provisioned_table_write_units(table_name)) * 100)
+    try:
+        throttled_by_provisioned_write_percent = (
+            float(throttled_write_events) / float(
+                dynamodb.get_provisioned_table_write_units(table_name)) * 100)
     except JSONResponseError:
         raise
 
@@ -214,7 +243,9 @@ def get_throttled_by_provisioned_write_event_percent(table_name, lookback_window
     return throttled_by_provisioned_write_percent
 
 
-def get_throttled_by_consumed_write_percent(table_name, lookback_window_start=15):
+def get_throttled_by_consumed_write_percent(table_name,
+                                            lookback_window_start=15,
+                                            lookback_period=5):
     """ Returns the number of throttled write events in percent of consumption
 
     :type table_name: str
@@ -226,15 +257,19 @@ def get_throttled_by_consumed_write_percent(table_name, lookback_window_start=15
 
     try:
         metrics1 = __get_aws_metric(
-            table_name, lookback_window_start, 'ConsumedWriteCapacityUnits')
+            table_name, lookback_window_start, lookback_period,
+            'ConsumedWriteCapacityUnits')
         metrics2 = __get_aws_metric(
-            table_name, lookback_window_start, 'WriteThrottleEvents')
+            table_name, lookback_window_start, lookback_period,
+            'WriteThrottleEvents')
     except BotoServerError:
         raise
 
     if metrics1 and metrics2:
-        throttled_by_consumed_write_percent = (((float(metrics2[0]['Sum'])/float(300)) /
-                                                (float(metrics1[0]['Sum'])/float(300))) * 100)
+        lookback_seconds = lookback_period * 60
+        throttled_by_consumed_write_percent = (
+            ((float(metrics2[0]['Sum']) / float(lookback_seconds)) /
+             (float(metrics1[0]['Sum']) / float(lookback_seconds))) * 100)
     else:
         throttled_by_consumed_write_percent = 0
 
@@ -248,7 +283,8 @@ def get_throttled_by_consumed_write_percent(table_name, lookback_window_start=15
     wait_exponential_multiplier=1000,
     wait_exponential_max=10000,
     stop_max_attempt_number=10)
-def __get_aws_metric(table_name, lookback_window_start, metric_name):
+def __get_aws_metric(table_name, lookback_window_start, lookback_period,
+                     metric_name):
     """ Returns a  metric list from the AWS CloudWatch service, may return
     None if no metric exists
 
@@ -256,6 +292,8 @@ def __get_aws_metric(table_name, lookback_window_start, metric_name):
     :param table_name: Name of the DynamoDB table
     :type lookback_window_start: int
     :param lookback_window_start: How many minutes to look at
+    :type lookback_period: int
+    :type lookback_period: Length of the lookback period in minutes
     :type metric_name: str
     :param metric_name: Name of the metric to retrieve from CloudWatch
     :returns: list -- A list of time series data for the given metric, may
@@ -263,11 +301,12 @@ def __get_aws_metric(table_name, lookback_window_start, metric_name):
     """
     try:
         now = datetime.utcnow()
-        start_time = now-timedelta(minutes=lookback_window_start)
-        end_time = now-timedelta(minutes=lookback_window_start-5)
+        start_time = now - timedelta(minutes=lookback_window_start)
+        end_time = now - timedelta(
+            minutes=lookback_window_start - lookback_period)
 
         return cloudwatch_connection.get_metric_statistics(
-            period=300,                 # Always look at 5 minutes windows
+            period=lookback_period * 60,
             start_time=start_time,
             end_time=end_time,
             metric_name=metric_name,


### PR DESCRIPTION
This should hopefully solve #259 however I'm unsure if having lookback-window-start have a minimum of 1 is a good idea, as you usually won't get much data between now()-1 and now(), maybe something like a minimum of 3 would be better so we can guarantee that we would have CloudWatch data. Let me know and I'll change it.