### PR TITLE
Support for granular downscaling

### DIFF
--- a/dynamic_dynamodb/config/__init__.py
+++ b/dynamic_dynamodb/config/__init__.py
@@ -86,7 +86,13 @@ DEFAULT_OPTIONS = {
         'increase_throttled_by_consumed_reads_unit': None,
         'increase_throttled_by_consumed_reads_scale': None,
         'increase_throttled_by_consumed_writes_unit': None,
-        'increase_throttled_by_consumed_writes_scale': None
+        'increase_throttled_by_consumed_writes_scale': None,
+        'decrease_consumed_reads_unit': None,
+        'decrease_consumed_reads_with': None,
+        'decrease_consumed_reads_scale': None,
+        'decrease_consumed_writes_unit': None,
+        'decrease_consumed_writes_with': None,
+        'decrease_consumed_writes_scale': None,
     },
     'gsi': {
         'reads-upper-alarm-threshold': 0,
@@ -440,13 +446,17 @@ def __check_gsi_rules(configuration):
                 'min_provisioned_writes',
                 'max_provisioned_writes',
                 'increase_consumed_reads_with',
-                'increase_consumed_writes_with'
+                'increase_consumed_writes_with',
+                'decrease_consumed_reads_with',
+                'decrease_consumed_writes_with'
             ]
             # Config options without a mandatory default
             # should be allowed a None value
             non_default = [
                 'increase_consumed_reads_with',
-                'increase_consumed_writes_with'
+                'increase_consumed_writes_with',
+                'decrease_consumed_reads_with',
+                'decrease_consumed_writes_with'
             ]
 
             for option in options:

--- a/dynamic_dynamodb/config/config_file_parser.py
+++ b/dynamic_dynamodb/config/config_file_parser.py
@@ -329,6 +329,42 @@ TABLE_CONFIG_OPTIONS = [
         'option': 'increase-consumed-writes-scale',
         'required': False,
         'type': 'dict'
+    },
+    {
+        'key': 'decrease_consumed_reads_unit',
+        'option': 'decrease-consumed-reads-unit',
+        'required': False,
+        'type': 'str'
+    },
+    {
+        'key': 'decrease_consumed_reads_with',
+        'option': 'decrease-consumed-reads-with',
+        'required': False,
+        'type': 'int'
+    },
+    {
+        'key': 'decrease_consumed_reads_scale',
+        'option': 'decrease-consumed-reads-scale',
+        'required': False,
+        'type': 'dict'
+    },
+    {
+        'key': 'decrease_consumed_writes_unit',
+        'option': 'decrease-consumed-writes-unit',
+        'required': False,
+        'type': 'str'
+    },
+    {
+        'key': 'decrease_consumed_writes_with',
+        'option': 'decrease-consumed-writes-with',
+        'required': False,
+        'type': 'int'
+    },
+    {
+        'key': 'decrease_consumed_writes_scale',
+        'option': 'decrease-consumed-writes-scale',
+        'required': False,
+        'type': 'dict'
     }
 ]
 

--- a/dynamic_dynamodb/core/gsi.py
+++ b/dynamic_dynamodb/core/gsi.py
@@ -230,6 +230,12 @@ def __ensure_provisioning_reads(
             get_gsi_option(table_key, gsi_key, 'increase_consumed_reads_with')
         increase_consumed_reads_scale = \
             get_gsi_option(table_key, gsi_key, 'increase_consumed_reads_scale')
+        decrease_consumed_reads_unit = \
+            get_gsi_option(table_key, gsi_key, 'decrease_consumed_reads_unit')
+        decrease_consumed_reads_with = \
+            get_gsi_option(table_key, gsi_key, 'decrease_consumed_reads_with')
+        decrease_consumed_reads_scale = \
+            get_gsi_option(table_key, gsi_key, 'decrease_consumed_reads_scale')
     except JSONResponseError:
         raise
     except BotoServerError:
@@ -462,8 +468,19 @@ def __ensure_provisioning_reads(
             updated_read_units = calculated_provisioning
 
     # Decrease needed due to low CU consumption
-    if (consumed_read_units_percent <= reads_lower_threshold
-            and not update_needed):
+    if not update_needed:
+        # If local/granular values not specified use global values
+        decrease_consumed_reads_unit = \
+            decrease_consumed_reads_unit or decrease_reads_unit
+
+        decrease_consumed_reads_with = \
+            decrease_consumed_reads_with or decrease_reads_with
+
+        # Initialise variables to store calculated provisioning
+        consumed_calculated_provisioning = scale_reader(
+            decrease_consumed_reads_scale,
+            consumed_read_units_percent)
+        calculated_provisioning = None
 
         # Exit if down scaling has been disabled
         if not get_gsi_option(table_key, gsi_key, 'enable_reads_down_scaling'):
@@ -473,22 +490,45 @@ def __ensure_provisioning_reads(
                 'down reads has been disabled in the configuration'.format(
                     table_name, gsi_name))
         else:
-            if decrease_reads_unit == 'percent':
-                calculated_provisioning = calculators.decrease_reads_in_percent(
-                    current_read_units,
-                    decrease_reads_with,
-                    get_gsi_option(table_key, gsi_key, 'min_provisioned_reads'),
-                    '{0} - GSI: {1}'.format(table_name, gsi_name))
-            else:
-                calculated_provisioning = calculators.decrease_reads_in_units(
-                    current_read_units,
-                    decrease_reads_with,
-                    get_gsi_option(table_key, gsi_key, 'min_provisioned_reads'),
-                    '{0} - GSI: {1}'.format(table_name, gsi_name))
+            if consumed_calculated_provisioning:
+                if decrease_consumed_reads_unit == 'percent':
+                    calculated_provisioning = \
+                        calculators.decrease_reads_in_percent(
+                            updated_read_units,
+                            consumed_calculated_provisioning,
+                            get_gsi_option(
+                                table_key, gsi_key, 'min_provisioned_reads'),
+                            '{0} - GSI: {1}'.format(table_name, gsi_name))
+                else:
+                    calculated_provisioning = \
+                        calculators.decrease_reads_in_units(
+                            updated_read_units,
+                            consumed_calculated_provisioning,
+                            get_gsi_option(
+                                table_key, gsi_key, 'min_provisioned_reads'),
+                            '{0} - GSI: {1}'.format(table_name, gsi_name))
+            elif (reads_lower_threshold
+                  and consumed_read_units_percent > reads_lower_threshold
+                  and not decrease_consumed_reads_scale):
+                if decrease_consumed_reads_unit == 'percent':
+                    calculated_provisioning = \
+                        calculators.decrease_reads_in_percent(
+                            updated_read_units,
+                            decrease_consumed_reads_with,
+                            get_gsi_option(
+                                table_key, gsi_key, 'min_provisioned_reads'),
+                            '{0} - GSI: {1}'.format(table_name, gsi_name))
+                else:
+                    calculated_provisioning = \
+                        calculators.decrease_reads_in_units(
+                            updated_read_units,
+                            decrease_consumed_reads_with,
+                            get_gsi_option(
+                                table_key, gsi_key, 'min_provisioned_reads'),
+                            '{0} - GSI: {1}'.format(table_name, gsi_name))
 
-            if current_read_units != calculated_provisioning:
-                # We need to look at how many times the num_consec_read_checks
-                # integer has incremented and Compare to config file value
+            if (calculated_provisioning
+                and current_read_units != calculated_provisioning):
                 num_consec_read_checks = num_consec_read_checks + 1
 
                 if num_consec_read_checks >= num_read_checks_before_scale_down:
@@ -623,6 +663,12 @@ def __ensure_provisioning_writes(
             get_gsi_option(table_key, gsi_key, 'increase_consumed_writes_with')
         increase_consumed_writes_scale = \
             get_gsi_option(table_key, gsi_key, 'increase_consumed_writes_scale')
+        decrease_consumed_writes_unit = \
+            get_gsi_option(table_key, gsi_key, 'decrease_consumed_writes_unit')
+        decrease_consumed_writes_with = \
+            get_gsi_option(table_key, gsi_key, 'decrease_consumed_writes_with')
+        decrease_consumed_writes_scale = \
+            get_gsi_option(table_key, gsi_key, 'decrease_consumed_writes_scale')
     except JSONResponseError:
         raise
     except BotoServerError:
@@ -848,8 +894,19 @@ def __ensure_provisioning_writes(
             updated_write_units = calculated_provisioning
 
     # Decrease needed due to low CU consumption
-    if (consumed_write_units_percent
-            <= writes_lower_threshold and not update_needed):
+    if not update_needed:
+        # If local/granular values not specified use global values
+        decrease_consumed_writes_unit = \
+            decrease_consumed_writes_unit or decrease_writes_unit
+
+        decrease_consumed_writes_with = \
+            decrease_consumed_writes_with or decrease_writes_with
+
+        # Initialise variables to store calculated provisioning
+        consumed_calculated_provisioning = scale_reader(
+            decrease_consumed_writes_scale,
+            consumed_write_units_percent)
+        calculated_provisioning = None
 
         # Exit if down scaling has been disabled
         if not get_gsi_option(table_key, gsi_key, 'enable_writes_down_scaling'):
@@ -859,29 +916,50 @@ def __ensure_provisioning_writes(
                 'down writes has been disabled in the configuration'.format(
                     table_name, gsi_name))
         else:
-            if decrease_writes_unit == 'percent':
-                calculated_provisioning = \
-                    calculators.decrease_writes_in_percent(
-                        current_write_units,
-                        decrease_writes_with,
-                        get_gsi_option(
-                            table_key, gsi_key, 'min_provisioned_writes'),
-                        '{0} - GSI: {1}'.format(table_name, gsi_name))
-            else:
-                calculated_provisioning = calculators.decrease_writes_in_units(
-                    current_write_units,
-                    decrease_writes_with,
-                    get_gsi_option(
-                        table_key, gsi_key, 'min_provisioned_writes'),
-                    '{0} - GSI: {1}'.format(table_name, gsi_name))
+            if consumed_calculated_provisioning:
+                if decrease_consumed_writes_unit == 'percent':
+                    calculated_provisioning = \
+                        calculators.decrease_writes_in_percent(
+                            updated_write_units,
+                            consumed_calculated_provisioning,
+                            get_gsi_option(
+                                table_key, gsi_key, 'min_provisioned_writes'),
+                            '{0} - GSI: {1}'.format(table_name, gsi_name))
+                else:
+                    calculated_provisioning = \
+                        calculators.decrease_writes_in_units(
+                            updated_write_units,
+                            consumed_calculated_provisioning,
+                            get_gsi_option(
+                                table_key, gsi_key, 'min_provisioned_writes'),
+                            '{0} - GSI: {1}'.format(table_name, gsi_name))
+            elif (writes_lower_threshold
+                  and consumed_write_units_percent > writes_lower_threshold
+                  and not decrease_consumed_writes_scale):
+                if decrease_consumed_writes_unit == 'percent':
+                    calculated_provisioning = \
+                        calculators.decrease_writes_in_percent(
+                            updated_write_units,
+                            decrease_consumed_writes_with,
+                            get_gsi_option(
+                                table_key, gsi_key, 'min_provisioned_writes'),
+                            '{0} - GSI: {1}'.format(table_name, gsi_name))
+                else:
+                    calculated_provisioning = \
+                        calculators.decrease_writes_in_units(
+                            updated_write_units,
+                            decrease_consumed_writes_with,
+                            get_gsi_option(
+                                table_key, gsi_key, 'min_provisioned_writes'),
+                            '{0} - GSI: {1}'.format(table_name, gsi_name))
 
-            if current_write_units != calculated_provisioning:
+            if (calculated_provisioning
+                and current_write_units != calculated_provisioning):
                 num_consec_write_checks = num_consec_write_checks + 1
 
-                if (num_consec_write_checks >=
-                        num_write_checks_before_scale_down):
+                if num_consec_write_checks >= num_write_checks_before_scale_down:
                     update_needed = True
-                    updated_write_units = calculated_provisioning
+                    updated_read_units = calculated_provisioning
 
     # Never go over the configured max provisioning
     if max_provisioned_writes:

--- a/dynamic_dynamodb/core/gsi.py
+++ b/dynamic_dynamodb/core/gsi.py
@@ -477,7 +477,7 @@ def __ensure_provisioning_reads(
             decrease_consumed_reads_with or decrease_reads_with
 
         # Initialise variables to store calculated provisioning
-        consumed_calculated_provisioning = scale_reader(
+        consumed_calculated_provisioning = scale_reader_decrease(
             decrease_consumed_reads_scale,
             consumed_read_units_percent)
         calculated_provisioning = None
@@ -903,7 +903,7 @@ def __ensure_provisioning_writes(
             decrease_consumed_writes_with or decrease_writes_with
 
         # Initialise variables to store calculated provisioning
-        consumed_calculated_provisioning = scale_reader(
+        consumed_calculated_provisioning = scale_reader_decrease(
             decrease_consumed_writes_scale,
             consumed_write_units_percent)
         calculated_provisioning = None
@@ -1187,6 +1187,27 @@ def scale_reader(provision_increase_scale, current_value):
                 return scale_value
             else:
                 scale_value = provision_increase_scale.get(limits)
+        return scale_value
+    else:
+        return scale_value
+
+def scale_reader_decrease(provision_decrease_scale, current_value):
+    """
+
+    :type provision_decrease_scale: dict
+    :param provision_decrease_scale: dictionary with key being the
+        scaling threshold and value being scaling amount
+    :type current_value: float
+    :param current_value: the current consumed units or throttled events
+    :returns: (int) The amount to scale provisioning by
+    """
+    scale_value = 0
+    if provision_decrease_scale:
+        for limits in sorted(provision_decrease_scale.keys(), reverse=True):
+            if current_value > limits:
+                return scale_value
+            else:
+                scale_value = provision_decrease_scale.get(limits)
         return scale_value
     else:
         return scale_value

--- a/dynamic_dynamodb/core/gsi.py
+++ b/dynamic_dynamodb/core/gsi.py
@@ -528,8 +528,8 @@ def __ensure_provisioning_reads(
                             '{0} - GSI: {1}'.format(table_name, gsi_name))
 
             if (calculated_provisioning
-                and current_read_units != calculated_provisioning):
-                num_consec_read_checks = num_consec_read_checks + 1
+                    and current_read_units != calculated_provisioning):
+                num_consec_read_checks += 1
 
                 if num_consec_read_checks >= num_read_checks_before_scale_down:
                     update_needed = True
@@ -636,7 +636,8 @@ def __ensure_provisioning_writes(
             get_gsi_option(
                 table_key, gsi_key, 'num_write_checks_before_scale_down')
         num_write_checks_reset_percent = \
-            get_gsi_option(table_key, gsi_key, 'num_write_checks_reset_percent')
+            get_gsi_option(
+                table_key, gsi_key, 'num_write_checks_reset_percent')
         increase_throttled_by_provisioned_writes_unit = \
             get_gsi_option(
                 table_key,
@@ -662,13 +663,15 @@ def __ensure_provisioning_writes(
         increase_consumed_writes_with = \
             get_gsi_option(table_key, gsi_key, 'increase_consumed_writes_with')
         increase_consumed_writes_scale = \
-            get_gsi_option(table_key, gsi_key, 'increase_consumed_writes_scale')
+            get_gsi_option(
+                table_key, gsi_key, 'increase_consumed_writes_scale')
         decrease_consumed_writes_unit = \
             get_gsi_option(table_key, gsi_key, 'decrease_consumed_writes_unit')
         decrease_consumed_writes_with = \
             get_gsi_option(table_key, gsi_key, 'decrease_consumed_writes_with')
         decrease_consumed_writes_scale = \
-            get_gsi_option(table_key, gsi_key, 'decrease_consumed_writes_scale')
+            get_gsi_option(
+                table_key, gsi_key, 'decrease_consumed_writes_scale')
     except JSONResponseError:
         raise
     except BotoServerError:
@@ -677,7 +680,8 @@ def __ensure_provisioning_writes(
     # Set the updated units to the current write unit value
     updated_write_units = current_write_units
 
-    # Reset write consecutive count if num_write_checks_reset_percent is reached
+    # Reset consecutive write count if num_write_checks_reset_percent
+    # is reached
     if num_write_checks_reset_percent:
 
         if consumed_write_units_percent >= num_write_checks_reset_percent:
@@ -909,7 +913,8 @@ def __ensure_provisioning_writes(
         calculated_provisioning = None
 
         # Exit if down scaling has been disabled
-        if not get_gsi_option(table_key, gsi_key, 'enable_writes_down_scaling'):
+        if not get_gsi_option(
+                table_key, gsi_key, 'enable_writes_down_scaling'):
             logger.debug(
                 '{0} - GSI: {1} - Down scaling event detected. '
                 'No action taken as scaling '
@@ -954,12 +959,13 @@ def __ensure_provisioning_writes(
                             '{0} - GSI: {1}'.format(table_name, gsi_name))
 
             if (calculated_provisioning
-                and current_write_units != calculated_provisioning):
-                num_consec_write_checks = num_consec_write_checks + 1
+                    and current_write_units != calculated_provisioning):
+                num_consec_write_checks += 1
 
-                if num_consec_write_checks >= num_write_checks_before_scale_down:
+                if num_consec_write_checks >= \
+                        num_write_checks_before_scale_down:
                     update_needed = True
-                    updated_read_units = calculated_provisioning
+                    updated_write_units = calculated_provisioning
 
     # Never go over the configured max provisioning
     if max_provisioned_writes:
@@ -1091,8 +1097,7 @@ def __ensure_provisioning_alarm(table_name, table_key, gsi_name, gsi_key):
     # Check upper alarm thresholds
     upper_alert_triggered = False
     upper_alert_message = []
-    if (reads_upper_alarm_threshold > 0 and
-            consumed_read_units_percent >= reads_upper_alarm_threshold):
+    if 0 < reads_upper_alarm_threshold <= consumed_read_units_percent:
         upper_alert_triggered = True
         upper_alert_message.append(
             '{0} - GSI: {1} - Consumed Read Capacity {2:d}% '
@@ -1103,8 +1108,7 @@ def __ensure_provisioning_alarm(table_name, table_key, gsi_name, gsi_key):
                 consumed_read_units_percent,
                 reads_upper_alarm_threshold))
 
-    if (writes_upper_alarm_threshold > 0 and
-            consumed_write_units_percent >= writes_upper_alarm_threshold):
+    if 0 < writes_upper_alarm_threshold <= consumed_write_units_percent:
         upper_alert_triggered = True
         upper_alert_message.append(
             '{0} - GSI: {1} - Consumed Write Capacity {2:d}% '
@@ -1190,6 +1194,7 @@ def scale_reader(provision_increase_scale, current_value):
         return scale_value
     else:
         return scale_value
+
 
 def scale_reader_decrease(provision_decrease_scale, current_value):
     """

--- a/dynamic_dynamodb/core/table.py
+++ b/dynamic_dynamodb/core/table.py
@@ -407,7 +407,7 @@ def __ensure_provisioning_reads(table_name, key_name, num_consec_read_checks):
             decrease_consumed_reads_with or decrease_reads_with
 
         # Initialise variables to store calculated provisioning
-        consumed_calculated_provisioning = scale_reader(
+        consumed_calculated_provisioning = scale_reader_decrease(
             decrease_consumed_reads_scale,
             consumed_read_units_percent)
         calculated_provisioning = None
@@ -780,11 +780,10 @@ def __ensure_provisioning_writes(
             decrease_consumed_writes_with or decrease_writes_with
 
         # Initialise variables to store calculated provisioning
-        consumed_calculated_provisioning = scale_reader(
+        consumed_calculated_provisioning = scale_reader_decrease(
             decrease_consumed_writes_scale,
             consumed_write_units_percent)
         calculated_provisioning = None
-        print decrease_consumed_writes_scale, consumed_write_units_percent
 
         # Exit if down scaling has been disabled
         if not get_table_option(key_name, 'enable_writes_down_scaling'):
@@ -1027,6 +1026,27 @@ def scale_reader(provision_increase_scale, current_value):
                 return scale_value
             else:
                 scale_value = provision_increase_scale.get(limits)
+        return scale_value
+    else:
+        return scale_value
+
+def scale_reader_decrease(provision_decrease_scale, current_value):
+    """
+
+    :type provision_decrease_scale: dict
+    :param provision_decrease_scale: dictionary with key being the
+        scaling threshold and value being scaling amount
+    :type current_value: float
+    :param current_value: the current consumed units or throttled events
+    :returns: (int) The amount to scale provisioning by
+    """
+    scale_value = 0
+    if provision_decrease_scale:
+        for limits in sorted(provision_decrease_scale.keys(), reverse=True):
+            if current_value > limits:
+                return scale_value
+            else:
+                scale_value = provision_decrease_scale.get(limits)
         return scale_value
     else:
         return scale_value

--- a/dynamic_dynamodb/core/table.py
+++ b/dynamic_dynamodb/core/table.py
@@ -195,6 +195,12 @@ def __ensure_provisioning_reads(table_name, key_name, num_consec_read_checks):
             get_table_option(key_name, 'increase_consumed_reads_with')
         increase_consumed_reads_scale = \
             get_table_option(key_name, 'increase_consumed_reads_scale')
+        decrease_consumed_reads_unit = \
+            get_table_option(key_name, 'decrease_consumed_reads_unit')
+        decrease_consumed_reads_with = \
+            get_table_option(key_name, 'decrease_consumed_reads_with')
+        decrease_consumed_reads_scale = \
+            get_table_option(key_name, 'decrease_consumed_reads_scale')
     except JSONResponseError:
         raise
     except BotoServerError:
@@ -392,8 +398,19 @@ def __ensure_provisioning_reads(table_name, key_name, num_consec_read_checks):
             updated_read_units = calculated_provisioning
 
     # Decrease needed due to low CU consumption
-    if (consumed_read_units_percent <= reads_lower_threshold
-            and not update_needed):
+    if not update_needed:
+        # If local/granular values not specified use global values
+        decrease_consumed_reads_unit = \
+            decrease_consumed_reads_unit or decrease_reads_unit
+
+        decrease_consumed_reads_with = \
+            decrease_consumed_reads_with or decrease_reads_with
+
+        # Initialise variables to store calculated provisioning
+        consumed_calculated_provisioning = scale_reader(
+            decrease_consumed_reads_scale,
+            consumed_read_units_percent)
+        calculated_provisioning = None
 
         # Exit if down scaling has been disabled
         if not get_table_option(key_name, 'enable_reads_down_scaling'):
@@ -402,20 +419,45 @@ def __ensure_provisioning_reads(table_name, key_name, num_consec_read_checks):
                 'down reads has been disabled in the configuration'.format(
                     table_name))
         else:
-            if decrease_reads_unit == 'percent':
-                calculated_provisioning = calculators.decrease_reads_in_percent(
-                    updated_read_units,
-                    decrease_reads_with,
-                    get_table_option(key_name, 'min_provisioned_reads'),
-                    table_name)
-            else:
-                calculated_provisioning = calculators.decrease_reads_in_units(
-                    updated_read_units,
-                    decrease_reads_with,
-                    get_table_option(key_name, 'min_provisioned_reads'),
-                    table_name)
+            if consumed_calculated_provisioning:
+                if decrease_consumed_reads_unit == 'percent':
+                    calculated_provisioning = \
+                        calculators.decrease_reads_in_percent(
+                            updated_read_units,
+                            consumed_calculated_provisioning,
+                            get_table_option(
+                                key_name, 'min_provisioned_reads'),
+                            table_name)
+                else:
+                    calculated_provisioning = \
+                        calculators.decrease_reads_in_units(
+                            updated_read_units,
+                            consumed_calculated_provisioning,
+                            get_table_option(
+                                key_name, 'min_provisioned_reads'),
+                            table_name)
+            elif (reads_lower_threshold
+                  and consumed_read_units_percent > reads_lower_threshold
+                  and not decrease_consumed_reads_scale):
+                if decrease_consumed_reads_unit == 'percent':
+                    calculated_provisioning = \
+                        calculators.decrease_reads_in_percent(
+                            updated_read_units,
+                            decrease_consumed_reads_with,
+                            get_table_option(
+                                key_name, 'min_provisioned_reads'),
+                            table_name)
+                else:
+                    calculated_provisioning = \
+                        calculators.decrease_reads_in_units(
+                            updated_read_units,
+                            decrease_consumed_reads_with,
+                            get_table_option(
+                                key_name, 'min_provisioned_reads'),
+                            table_name)
 
-            if current_read_units != calculated_provisioning:
+            if (calculated_provisioning
+                    and current_read_units != calculated_provisioning):
                 num_consec_read_checks = num_consec_read_checks + 1
 
                 if num_consec_read_checks >= num_read_checks_before_scale_down:
@@ -524,6 +566,12 @@ def __ensure_provisioning_writes(
             get_table_option(key_name, 'increase_consumed_writes_with')
         increase_consumed_writes_scale = \
             get_table_option(key_name, 'increase_consumed_writes_scale')
+        decrease_consumed_writes_unit = \
+            get_table_option(key_name, 'decrease_consumed_writes_unit')
+        decrease_consumed_writes_with = \
+            get_table_option(key_name, 'decrease_consumed_writes_with')
+        decrease_consumed_writes_scale = \
+            get_table_option(key_name, 'decrease_consumed_writes_scale')
     except JSONResponseError:
         raise
     except BotoServerError:
@@ -723,35 +771,70 @@ def __ensure_provisioning_writes(
             updated_write_units = calculated_provisioning
 
     # Decrease needed due to low CU consumption
-    if (consumed_write_units_percent
-            <= writes_lower_threshold and not update_needed):
+    if not update_needed:
+        # If local/granular values not specified use global values
+        decrease_consumed_writes_unit = \
+            decrease_consumed_writes_unit or decrease_writes_unit
 
-        # Exit if up scaling has been disabled
+        decrease_consumed_writes_with = \
+            decrease_consumed_writes_with or decrease_writes_with
+
+        # Initialise variables to store calculated provisioning
+        consumed_calculated_provisioning = scale_reader(
+            decrease_consumed_writes_scale,
+            consumed_write_units_percent)
+        calculated_provisioning = None
+        print decrease_consumed_writes_scale, consumed_write_units_percent
+
+        # Exit if down scaling has been disabled
         if not get_table_option(key_name, 'enable_writes_down_scaling'):
             logger.debug(
-                '{0} - Down scaling event detected. No action taken as scaling '
+                '{0} - Down scaling event detected. No action taken as scaling'
                 'down writes has been disabled in the configuration'.format(
                     table_name))
         else:
-            if decrease_writes_unit == 'percent':
-                calculated_provisioning = \
-                    calculators.decrease_writes_in_percent(
-                        current_write_units,
-                        decrease_writes_with,
-                        get_table_option(key_name, 'min_provisioned_writes'),
-                        table_name)
-            else:
-                calculated_provisioning = calculators.decrease_writes_in_units(
-                    current_write_units,
-                    decrease_writes_with,
-                    get_table_option(key_name, 'min_provisioned_writes'),
-                    table_name)
+            if consumed_calculated_provisioning:
+                if decrease_writes_unit == 'percent':
+                    calculated_provisioning = \
+                        calculators.decrease_writes_in_percent(
+                            updated_write_units,
+                            consumed_calculated_provisioning,
+                            get_table_option(
+                                key_name, 'min_provisioned_writes'),
+                            table_name)
+                else:
+                    calculated_provisioning = \
+                        calculators.decrease_writes_in_units(
+                            updated_write_units,
+                            consumed_calculated_provisioning,
+                            get_table_option(
+                                key_name, 'min_provisioned_writes'),
+                            table_name)
+            elif (writes_lower_threshold
+                  and consumed_write_units_percent > writes_lower_threshold
+                  and not decrease_consumed_writes_scale):
+                if decrease_writes_unit == 'percent':
+                    calculated_provisioning = \
+                        calculators.decrease_writes_in_percent(
+                            updated_write_units,
+                            decrease_writes_with,
+                            get_table_option(
+                                key_name, 'min_provisioned_writes'),
+                            table_name)
+                else:
+                    calculated_provisioning = \
+                        calculators.decrease_writes_in_units(
+                            updated_write_units,
+                            decrease_writes_with,
+                            get_table_option(
+                                key_name, 'min_provisioned_writes'),
+                            table_name)
 
-            if current_write_units != calculated_provisioning:
+            if (calculated_provisioning and
+                    current_write_units != calculated_provisioning):
                 num_consec_write_checks = num_consec_write_checks + 1
 
-                if (num_consec_write_checks >=
-                        num_write_checks_before_scale_down):
+                if num_consec_write_checks >= num_write_checks_before_scale_down:
                     update_needed = True
                     updated_write_units = calculated_provisioning
 


### PR DESCRIPTION
Much like #258, add granular downscaling as well. Only supports downscaling on consumed vs provisioned capacity, as I can't imagine a situation where one would want to scale DOWN when they have throttling.

With this kind of setup a user could, for example, only scale down slightly when at a certain point, but also immediately scale all the way down to 1 read/write unit when they have 0% utilization. This would prevent a situation like described in #245 where the autoscaler would only downscale very few units each iteration, risking bumping up against the downscale limit.

I'll work on the docs if this looks good to you.

On a side note, I think a lot of this code could be consolidated together, as I performed more copy/paste of large chunks of code than I'd care to admit, but I figured that refactoring would be out of the scope of this feature. I'd like to visit it after this and my other PRs are merged, though.