### PR TITLE
 Don't scale down table to max if current consumption is over max

### DIFF
--- a/dynamic_dynamodb/calculators.py
+++ b/dynamic_dynamodb/calculators.py
@@ -339,6 +339,25 @@ def increase_writes_in_units(
     return updated_provisioning
 
 
+def is_consumed_over_max(
+        current_provisioning, max_provisioning, consumed_units_percent):
+    """
+    Determines if the currently consumed capacity is over the max capacity for
+    this table
+
+    :type current_provisioning: int
+    :param current_provisioning: The current provisioning
+    :type max_provisioning: int
+    :param max_provisioning: Configured max provisioned units
+    :type consumed_units_percent: float
+    :param consumed_units_percent: Percent of consumed units
+    :returns: bool - if consumed is over max
+    """
+    consumption_based_current_provisioning = \
+        int(math.ceil(current_provisioning*(consumed_units_percent/100)))
+    return consumption_based_current_provisioning > max_provisioning
+
+
 def __get_min_reads(current_provisioning, min_provisioned_reads, log_tag):
     """ Get the minimum number of reads to current_provisioning
 

--- a/dynamic_dynamodb/core/table.py
+++ b/dynamic_dynamodb/core/table.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """ Core components """
 from boto.exception import JSONResponseError, BotoServerError
-import sys
 
 from dynamic_dynamodb import calculators
 from dynamic_dynamodb.aws import dynamodb, sns

--- a/dynamic_dynamodb/core/table.py
+++ b/dynamic_dynamodb/core/table.py
@@ -798,6 +798,7 @@ def __ensure_provisioning_writes(
         table_name,
         num_consec_write_checks,
         num_write_checks_before_scale_down))
+
     return update_needed, updated_write_units, num_consec_write_checks
 
 


### PR DESCRIPTION
This PR will prevent the autoscaler from lowering the throughput to the maximum if the consumed amount is currently above the max. This would prevent a situation where the autoscaler would do more harm than good.

I ran into this issue yesterday when I was doing a an ETL job on a large table. I had raised it's throughput up to a very high amount, and was doing an EMR job to extract it, however the autoscaler reduced it to it's max setting, which was well below what was being consumed at the time, causing the ETL to throttle and fail.