### PR TITLE
Don't scale down if it would scale below the current consumed units

### DIFF
--- a/dynamic_dynamodb/calculators.py
+++ b/dynamic_dynamodb/calculators.py
@@ -339,6 +339,25 @@ def increase_writes_in_units(
     return updated_provisioning
 
 
+def is_consumed_over_proposed(
+        current_provisioning, proposed_provisioning, consumed_units_percent):
+    """
+    Determines if the currently consumed capacity is over the proposed capacity
+    for this table
+
+    :type current_provisioning: int
+    :param current_provisioning: The current provisioning
+    :type proposed_provisioning: int
+    :param proposed_provisioning: New provisioning
+    :type consumed_units_percent: float
+    :param consumed_units_percent: Percent of consumed units
+    :returns: bool - if consumed is over max
+    """
+    consumption_based_current_provisioning = \
+        int(math.ceil(current_provisioning*(consumed_units_percent/100)))
+    return consumption_based_current_provisioning > proposed_provisioning
+
+
 def __get_min_reads(current_provisioning, min_provisioned_reads, log_tag):
     """ Get the minimum number of reads to current_provisioning
 

--- a/dynamic_dynamodb/core/gsi.py
+++ b/dynamic_dynamodb/core/gsi.py
@@ -521,6 +521,16 @@ def __ensure_provisioning_reads(
                     gsi_name,
                     updated_read_units))
 
+    if calculators.is_consumed_over_proposed(
+            current_read_units,
+            updated_read_units,
+            consumed_read_units_percent):
+        update_needed = False
+    updated_read_units = current_read_units
+    logger.info(
+        '{0} - GSI: {1} - Consumed is over proposed read units. Will leave '
+        'table at current setting.'.format(table_name, gsi_name))
+
     logger.info('{0} - GSI: {1} - Consecutive read checks {2}/{3}'.format(
         table_name,
         gsi_name,
@@ -908,6 +918,16 @@ def __ensure_provisioning_writes(
                     table_name,
                     gsi_name,
                     updated_write_units))
+
+    if calculators.is_consumed_over_proposed(
+            current_write_units,
+            updated_write_units,
+            consumed_write_units_percent):
+        update_needed = False
+    updated_write_units = current_write_units
+    logger.info(
+        '{0} - GSI: {1} - Consumed is over proposed write units. Will leave '
+        'table at current setting.'.format(table_name, gsi_name))
 
     logger.info('{0} - GSI: {1} - Consecutive write checks {2}/{3}'.format(
         table_name,

--- a/dynamic_dynamodb/core/table.py
+++ b/dynamic_dynamodb/core/table.py
@@ -440,6 +440,16 @@ def __ensure_provisioning_reads(table_name, key_name, num_consec_read_checks):
                 '{0} - Increasing reads to meet min-provisioned-reads '
                 'limit ({1} reads)'.format(table_name, updated_read_units))
 
+    if calculators.is_consumed_over_proposed(
+            current_read_units,
+            updated_read_units,
+            consumed_read_units_percent):
+        update_needed = False
+        updated_read_units = current_read_units
+        logger.info(
+            '{0} - Consumed is over proposed read units. Will leave table at '
+            'current setting.'.format(table_name))
+
     logger.info('{0} - Consecutive read checks {1}/{2}'.format(
         table_name,
         num_consec_read_checks,
@@ -772,6 +782,16 @@ def __ensure_provisioning_writes(
             logger.info(
                 '{0} - Increasing writes to meet min-provisioned-writes '
                 'limit ({1} writes)'.format(table_name, updated_write_units))
+
+    if calculators.is_consumed_over_proposed(
+            current_write_units,
+            updated_write_units,
+            consumed_write_units_percent):
+        update_needed = False
+        updated_write_units = current_write_units
+        logger.info(
+            '{0} - Consumed is over proposed write units. Will leave table at '
+            'current setting.'.format(table_name))
 
     logger.info('{0} - Consecutive write checks {1}/{2}'.format(
         table_name,


### PR DESCRIPTION
Improved version of #267. This would also prevent a situation where a user has an error in their config, where they would scale down further than the consumed.