### PR TITLE
fix tuple issue for pip for python < 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def return_requires():
         'requests >= 0.14.1',
         'logutils >= 0.3.3',
         'retrying >= 1.3.3'
-    ],
+    ]
     if sys.version_info < (2, 7):
         install_requires.append('ordereddict >= 1.1')
     return install_requires


### PR DESCRIPTION
pip install fails with:

Collecting dynamic-dynamodb
  Using cached dynamic-dynamodb-2.0.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-XB7_kB/dynamic-dynamodb/setup.py", line 36, in <module>
        install_requires=return_requires(),
      File "/tmp/pip-build-XB7_kB/dynamic-dynamodb/setup.py", line 19, in return_requires
        install_requires.append('ordereddict >= 1.1')
    AttributeError: 'tuple' object has no attribute 'append'