### PR TITLE
ordereddict issue

### DIFF
--- a/dynamic_dynamodb/config/__init__.py
+++ b/dynamic_dynamodb/config/__init__.py
@@ -7,7 +7,7 @@ from dynamic_dynamodb.config import command_line_parser
 try:
     from collections import OrderedDict as ordereddict
 except ImportError:
-    import ordereddict
+    from ordereddict import OrderedDict as ordereddict
 
 DEFAULT_OPTIONS = {
     'global': {

--- a/dynamic_dynamodb/config/config_file_parser.py
+++ b/dynamic_dynamodb/config/config_file_parser.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 try:
     from collections import OrderedDict as ordereddict
 except ImportError:
-    import ordereddict
+    from ordereddict import OrderedDict as ordereddict
 
 TABLE_CONFIG_OPTIONS = [
     {


### PR DESCRIPTION
I pulled and tried to build since the pip install isn't working on python 2.6 and ended up with this error:

[root@ip-172-31-49-215 config]# dynamic-dynamodb --config /home/ec2-user/dynamic-dynamodb.conf
Traceback (most recent call last):
  File "/usr/bin/dynamic-dynamodb", line 4, in <module>
    __import__('pkg_resources').run_script('dynamic-dynamodb==2.1.0', 'dynamic-dynamodb')
  File "/usr/lib/python2.6/dist-packages/pkg_resources/__init__.py", line 735, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python2.6/dist-packages/pkg_resources/__init__.py", line 1652, in run_script
    exec(code, namespace, namespace)
  File "/usr/lib/python2.6/dist-packages/dynamic_dynamodb-2.1.0-py2.6.egg/EGG-INFO/scripts/dynamic-dynamodb", line 22, in <module>
    import dynamic_dynamodb
  File "/usr/lib/python2.6/dist-packages/dynamic_dynamodb-2.1.0-py2.6.egg/dynamic_dynamodb/__init__.py", line 29, in <module>
    from dynamic_dynamodb.aws import dynamodb
  File "/usr/lib/python2.6/dist-packages/dynamic_dynamodb-2.1.0-py2.6.egg/dynamic_dynamodb/aws/dynamodb.py", line 12, in <module>
    from dynamic_dynamodb.log_handler import LOGGER as logger
  File "/usr/lib/python2.6/dist-packages/dynamic_dynamodb-2.1.0-py2.6.egg/dynamic_dynamodb/log_handler.py", line 26, in <module>
    import config_handler
  File "/usr/lib/python2.6/dist-packages/dynamic_dynamodb-2.1.0-py2.6.egg/dynamic_dynamodb/config_handler.py", line 5, in <module>
    CONFIGURATION = config.get_configuration()
  File "/usr/lib/python2.6/dist-packages/dynamic_dynamodb-2.1.0-py2.6.egg/dynamic_dynamodb/config/__init__.py", line 163, in get_configuration
    'tables': ordereddict()
TypeError: 'module' object is not callable

I'm not a python programmer, but these changes fixed it, enough to allow it to run.