### PR TITLE
Make circuit breaker a per-table/gsi config option

### DIFF
--- a/docs/configuration_options.rst
+++ b/docs/configuration_options.rst
@@ -11,11 +11,11 @@ Global configuration
 ===================================== ========= ============= ==========================================
 Option                                Type      Default       Comment
 ===================================== ========= ============= ==========================================
-aws-access-key-id                     ``str``                  AWS access API key
-aws-secret-access-key-id              ``str``                  AWS secret API key
+aws-access-key-id                     ``str``                 AWS access API key
+aws-secret-access-key-id              ``str``                 AWS secret API key
 check-interval                        ``int``   300           How many seconds to wait between the checks
 circuit-breaker-timeout               ``float`` 10000.00      Timeout for the circuit breaker, in ms
-circuit-breaker-url                   ``str``                  URL to poll for circuit breaking. Dynamic DynamoDB will only run if the circuit breaker returns ``HTTP/200``
+circuit-breaker-url                   ``str``                 URL to poll for circuit breaking. Dynamic DynamoDB will only run if the circuit breaker returns ``HTTP/200``. When polling the URL, the headers ``x-table-name`` and ``x-gsi-name`` will be sent identifying the table and GSI names, if applicable.
 region                                ``str``   ``us-east-1`` AWS region to use
 ===================================== ========= ============= ==========================================
 
@@ -47,6 +47,8 @@ Option                                          Type      Default               
 allow-scaling-down-reads-on-0-percent           ``bool``  ``false``                   Allow down-scaling of reads when 0% is used.
 allow-scaling-down-writes-on-0-percent          ``bool``  ``false``                   Allow down-scaling of writes when 0% is used.
 always-decrease-rw-together                     ``bool``  ``false``                   Restrict scale down to only happen when both reads AND writes are in need of scaling down. Set this to ``true`` to minimize down-scaling.
+circuit-breaker-timeout                         ``float`` 10000.00                    Timeout for the circuit breaker, in ms. Overrides the global setting if set.
+circuit-breaker-url                             ``str``                               URL to poll for circuit breaking. Dynamic DynamoDB will only run if the circuit breaker returns ``HTTP/200``. Overrides the global setting if set. When polling the URL, the header ``x-table-name`` will be sent identifying the table name.
 decrease-reads-unit                             ``str``   ``percent``                 Set if we should scale down reads in ``units`` or ``percent``
 decrease-reads-with                             ``int``   50                          Number of ``units`` or ``percent`` we should scale down the read provisioning with. Choose entity with ``decrease-reads-unit``.
 decrease-writes-unit                            ``str``   ``percent``                 Set if we should scale down in ``units`` or ``percent``
@@ -134,6 +136,8 @@ Option                                          Type      Default               
 allow-scaling-down-reads-on-0-percent           ``bool``  ``false``                   Allow down-scaling of reads when 0% is used.
 allow-scaling-down-writes-on-0-percent          ``bool``  ``false``                   Allow down-scaling of writes when 0% is used.
 always-decrease-rw-together                     ``bool``  ``false``                   Restrict scale down to only happen when both reads AND writes are in need of scaling down. Set this to ``true`` to minimize down-scaling.
+circuit-breaker-timeout                         ``float`` 10000.00                    Timeout for the circuit breaker, in ms. Overrides the global setting if set.
+circuit-breaker-url                             ``str``                               URL to poll for circuit breaking. Dynamic DynamoDB will only run if the circuit breaker returns ``HTTP/200``. Overrides the global setting if set. When polling the URL, the headers ``x-table-name`` and ``x-gsi-name`` will be sent identifying the table and GSI names.
 decrease-reads-unit                             ``str``   ``percent``                 Set if we should scale down reads in ``units`` or ``percent``
 decrease-reads-with                             ``int``   50                          Number of ``units`` or ``percent`` we should scale down the read provisioning with. Choose entity with ``decrease-reads-unit``.
 decrease-writes-unit                            ``str``   ``percent``                 Set if we should scale down in ``units`` or ``percent``

--- a/dynamic_dynamodb/config/__init__.py
+++ b/dynamic_dynamodb/config/__init__.py
@@ -94,6 +94,8 @@ DEFAULT_OPTIONS = {
         'decrease_consumed_writes_unit': None,
         'decrease_consumed_writes_with': None,
         'decrease_consumed_writes_scale': None,
+        'circuit_breaker_url': None,
+        'circuit_breaker_timeout': 10000.00
     },
     'gsi': {
         'reads-upper-alarm-threshold': 0,
@@ -149,7 +151,9 @@ DEFAULT_OPTIONS = {
         'increase_throttled_by_consumed_reads_unit': None,
         'increase_throttled_by_consumed_reads_scale': None,
         'increase_throttled_by_consumed_writes_unit': None,
-        'increase_throttled_by_consumed_writes_scale': None
+        'increase_throttled_by_consumed_writes_scale': None,
+        'circuit_breaker_url': None,
+        'circuit_breaker_timeout': 10000.00
     }
 }
 

--- a/dynamic_dynamodb/config/config_file_parser.py
+++ b/dynamic_dynamodb/config/config_file_parser.py
@@ -371,7 +371,20 @@ TABLE_CONFIG_OPTIONS = [
         'option': 'decrease-consumed-writes-scale',
         'required': False,
         'type': 'dict'
-    }
+    },
+    {
+        'key': 'circuit_breaker_url',
+        'option': 'circuit-breaker-url',
+        'required': False,
+        'type': 'str'
+    },
+    {
+        'key': 'circuit_breaker_timeout',
+        'option': 'circuit-breaker-timeout',
+        'required': False,
+        'type': 'float'
+    },
+
 ]
 
 

--- a/dynamic_dynamodb/core/circuit_breaker.py
+++ b/dynamic_dynamodb/core/circuit_breaker.py
@@ -6,12 +6,17 @@ import sys
 import requests
 
 from dynamic_dynamodb.log_handler import LOGGER as logger
-from dynamic_dynamodb.config_handler import get_global_option
+from dynamic_dynamodb.config_handler import get_global_option, \
+    get_table_option, get_gsi_option
 
 
-def is_open():
+def is_open(table_name=None, table_key=None, gsi_name=None, gsi_key=None):
     """ Checks whether the circuit breaker is open
 
+    :param table_name: Name of the table being checked
+    :param table_key: Configuration key for table
+    :param gsi_name: Name of the GSI being checked
+    :param gsi_key: Configuration key for the GSI
     :returns: bool -- True if the circuit is open
     """
     logger.debug('Checking circuit breaker status')
@@ -22,11 +27,22 @@ def is_open():
         r'((?P<username>.+):(?P<password>.+)@){0,1}'
         r'(?P<url>.*)$'
     )
-    match = pattern.match(get_global_option('circuit_breaker_url'))
 
+    url = timeout = None
+    if gsi_name:
+        url = get_gsi_option(table_key, gsi_key, 'circuit_breaker_url')
+        timeout = get_gsi_option(table_key, gsi_key, 'circuit_breaker_timeout')
+    elif table_name:
+        url = get_table_option(table_key, 'circuit_breaker_url')
+        timeout = get_table_option(table_key, 'circuit_breaker_timeout')
+
+    if not url:
+        url = get_global_option('circuit_breaker_url')
+        timeout = get_global_option('circuit_breaker_timeout')
+
+    match = pattern.match(url)
     if not match:
-        logger.error('Malformatted URL: {0}'.format(
-            get_global_option('circuit_breaker_url')))
+        logger.error('Malformatted URL: {0}'.format(url))
         sys.exit(1)
 
     use_basic_auth = False
@@ -34,21 +50,24 @@ def is_open():
         use_basic_auth = True
 
     # Make the actual URL to call
+    auth = ()
     if use_basic_auth:
         url = '{scheme}{url}'.format(
             scheme=match.group('scheme'),
             url=match.group('url'))
         auth = (match.group('username'), match.group('password'))
-    else:
-        url = get_global_option('circuit_breaker_url')
-        auth = ()
+
+    headers = {"x-table-name": table_name}
+    if gsi_name:
+        headers["x-gsi-name"] = gsi_name
 
     # Make the actual request
     try:
         response = requests.get(
             url,
             auth=auth,
-            timeout=get_global_option('circuit_breaker_timeout') / 1000.00)
+            timeout=timeout / 1000.00,
+            headers=headers)
         if int(response.status_code) == 200:
             logger.info('Circuit breaker is closed')
             return False

--- a/dynamic_dynamodb/core/circuit_breaker.py
+++ b/dynamic_dynamodb/core/circuit_breaker.py
@@ -57,7 +57,9 @@ def is_open(table_name=None, table_key=None, gsi_name=None, gsi_key=None):
             url=match.group('url'))
         auth = (match.group('username'), match.group('password'))
 
-    headers = {"x-table-name": table_name}
+    headers = {}
+    if table_name:
+        headers["x-table-name"] = table_name
     if gsi_name:
         headers["x-gsi-name"] = gsi_name
 

--- a/dynamic_dynamodb/core/gsi.py
+++ b/dynamic_dynamodb/core/gsi.py
@@ -29,8 +29,9 @@ def ensure_provisioning(
     :param num_consec_write_checks: How many consecutive checks have we had
     :returns: (int, int) -- num_consec_read_checks, num_consec_write_checks
     """
-    if get_global_option('circuit_breaker_url'):
-        if circuit_breaker.is_open():
+    if get_global_option('circuit_breaker_url') or get_gsi_option(
+            table_key, gsi_key, 'circuit_breaker_url'):
+        if circuit_breaker.is_open(table_name, table_key, gsi_name, gsi_key):
             logger.warning('Circuit breaker is OPEN!')
             return (0, 0)
 

--- a/dynamic_dynamodb/core/table.py
+++ b/dynamic_dynamodb/core/table.py
@@ -27,8 +27,9 @@ def ensure_provisioning(
     :returns: (int, int) -- num_consec_read_checks, num_consec_write_checks
     """
 
-    if get_global_option('circuit_breaker_url'):
-        if circuit_breaker.is_open():
+    if get_global_option('circuit_breaker_url') or get_table_option(
+            key_name, 'circuit_breaker_url'):
+        if circuit_breaker.is_open(table_name, key_name):
             logger.warning('Circuit breaker is OPEN!')
             return (0, 0)
 


### PR DESCRIPTION
Additionally send the table and/or gsi as headers to the circuit breaker URL. This should allow users to implement per-table/gsi behavior without needing to change their configs at all.