### PR TITLE
Make sure we aren't downscaling if disabled in the config

### DIFF
--- a/dynamic_dynamodb/aws/dynamodb.py
+++ b/dynamic_dynamodb/aws/dynamodb.py
@@ -279,6 +279,23 @@ def update_table_provisioning(
     current_reads = int(get_provisioned_table_read_units(table_name))
     current_writes = int(get_provisioned_table_write_units(table_name))
 
+    # Make sure we aren't scaling down if we turned off downscaling
+    if (not get_table_option(key_name, 'enable_reads_down_scaling') or
+            not get_table_option(key_name, 'enable_writes_down_scaling')):
+        if (not get_table_option(key_name, 'enable_reads_down_scaling') or
+                current_reads > reads):
+            reads = current_reads
+        if (not get_table_option(key_name, 'enable_writes_down_scaling') and
+                current_writes > writes):
+            writes = current_writes
+
+        # Return if we do not need to scale at all
+        if reads == current_reads and writes == current_writes:
+            logger.info(
+                '{0} - No need to scale up reads nor writes'.format(
+                    table_name))
+            return
+
     if retry_with_only_increase:
         # Ensure that we are only doing increases
         if current_reads > reads:
@@ -423,6 +440,26 @@ def update_gsi_provisioning(
     """
     current_reads = int(get_provisioned_gsi_read_units(table_name, gsi_name))
     current_writes = int(get_provisioned_gsi_write_units(table_name, gsi_name))
+
+    # Make sure we aren't scaling down if we turned off downscaling
+    if (not get_gsi_option(table_key, gsi_key, 'enable_reads_down_scaling') or
+            not get_gsi_option(
+                table_key, gsi_key, 'enable_writes_down_scaling')):
+        if (not get_gsi_option(
+                table_key, gsi_key, 'enable_reads_down_scaling') and
+                current_reads > reads):
+            reads = current_reads
+        if (not get_gsi_option(
+                table_key, gsi_key, 'enable_writes_down_scaling') and
+                current_writes > writes):
+            writes = current_writes
+
+        # Return if we do not need to scale at all
+        if reads == current_reads and writes == current_writes:
+            logger.info(
+                '{0} - No need to scale up reads nor writes'.format(
+                    table_name))
+            return
 
     if retry_with_only_increase:
         # Ensure that we are only doing increases

--- a/dynamic_dynamodb/aws/dynamodb.py
+++ b/dynamic_dynamodb/aws/dynamodb.py
@@ -282,7 +282,7 @@ def update_table_provisioning(
     # Make sure we aren't scaling down if we turned off downscaling
     if (not get_table_option(key_name, 'enable_reads_down_scaling') or
             not get_table_option(key_name, 'enable_writes_down_scaling')):
-        if (not get_table_option(key_name, 'enable_reads_down_scaling') or
+        if (not get_table_option(key_name, 'enable_reads_down_scaling') and
                 current_reads > reads):
             reads = current_reads
         if (not get_table_option(key_name, 'enable_writes_down_scaling') and


### PR DESCRIPTION
I ran into an issue today where the autoscaler still decided to downscale my table despite being disabled in the config. Turns out that the autoscaler will ignore this setting if it wants to downscale a table to bring it down to the max. I figured this was not intentional, so I made a check for downscaling being disabled right before the throughput is going to get changed to prevent something like this from happening.