### PR TITLE
Security fix

### DIFF
--- a/dynamic_dynamodb/daemon.py
+++ b/dynamic_dynamodb/daemon.py
@@ -44,7 +44,6 @@ class Daemon:
         # decouple from parent environment
         os.chdir("/")
         os.setsid()
-        os.umask(0)
 
         # do second fork
         try:


### PR DESCRIPTION
When umask is set to 0 it leaves pid and log files available with write permissions to everyone.