### PR TITLE
Add a --show-config option that prints the configuration to stdout or errors

### DIFF
--- a/dynamic_dynamodb/__init__.py
+++ b/dynamic_dynamodb/__init__.py
@@ -20,6 +20,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import json
 import re
 import sys
 import time
@@ -56,7 +57,7 @@ def main():
     """ Main function called from dynamic-dynamodb """
     try:
         if get_global_option('show_config'):
-            print config.get_configuration()
+            print json.dumps(config.get_configuration(), indent=2)
         elif get_global_option('daemon'):
             daemon = DynamicDynamoDBDaemon(
                 '{0}/dynamic-dynamodb.{1}.pid'.format(

--- a/dynamic_dynamodb/__init__.py
+++ b/dynamic_dynamodb/__init__.py
@@ -55,7 +55,9 @@ class DynamicDynamoDBDaemon(Daemon):
 def main():
     """ Main function called from dynamic-dynamodb """
     try:
-        if get_global_option('daemon'):
+        if get_global_option('show_config'):
+            print config.get_configuration()
+        elif get_global_option('daemon'):
             daemon = DynamicDynamoDBDaemon(
                 '{0}/dynamic-dynamodb.{1}.pid'.format(
                     get_global_option('pid_file_dir'),

--- a/dynamic_dynamodb/config/__init__.py
+++ b/dynamic_dynamodb/config/__init__.py
@@ -16,6 +16,7 @@ DEFAULT_OPTIONS = {
         'daemon': False,
         'instance': 'default',
         'dry_run': False,
+        'show_config': False,
         'pid_file_dir': '/tmp',
         'run_once': False,
 

--- a/dynamic_dynamodb/config/command_line_parser.py
+++ b/dynamic_dynamodb/config/command_line_parser.py
@@ -22,6 +22,10 @@ def parse():
         action='store_true',
         help='Run once and then exit Dynamic DynamoDB, instead of looping')
     parser.add_argument(
+        '--show-config',
+        action='store_true',
+        help='Parse config files, print parsed data and then exit Dynamic DynamoDB')
+    parser.add_argument(
         '--check-interval',
         type=int,
         help="""How many seconds should we wait between


### PR DESCRIPTION
I have recently deployed an invalid configuration of dynamic-dynamodb to production, and having taken a while to notice and work out what's going on, I started looking for a way to make my docker container build fail if the syntax of the configuration I've just changed is invalid, without having to do a --dry-run --run-once - which takes time if you have a lot of tables, and also needs access to the production systems (otherwise it'll return an error).

I thought it would also be useful to show the full configuration as cheap and cheerful json, as it's built up from the command line, configuration file and defaults, though the big benefit for me would be having the return code and the failure reason.

```
~/git-external/dynamic-dynamodb$ python dynamic-dynamodb --show-config || echo FAIL
{
  "tables": {}, 
  "global": {
    "circuit_breaker_url": null, 
    "daemon": false, 
    "aws_secret_access_key": null, 
    "dry_run": false, 
    "circuit_breaker_timeout": 10000.0, 
    "pid_file_dir": "/tmp", 
    "region": "us-east-1", 
    "show_config": true, 
    "run_once": false, 
    "instance": "default", 
    "check_interval": 300, 
    "config": null, 
    "aws_access_key_id": null
  }, 
  "logging": {
    "log_file": null, 
    "log_level": "info", 
    "log_config_file": null
  }
}
```

Or if I give it a broken configuration file:
```
~/git-external/dynamic-dynamodb$ python dynamic-dynamodb --show-config -c broken.conf || echo FAIL
Could not find a [table: <table_name>] section in broken.conf
FAIL
```