### PR TITLE
Prevents scaling down write capacity as long as there are throttled w…

### DIFF
--- a/dynamic_dynamodb/core/table.py
+++ b/dynamic_dynamodb/core/table.py
@@ -805,6 +805,12 @@ def __ensure_provisioning_writes(
                 '{0} - Down scaling event detected. No action taken as scaling'
                 ' down writes is not done when usage is at 0%'.format(
                     table_name))
+        # Exit if writes are still throttled
+        elif (throttled_writes_upper_threshold
+              and throttled_write_count > throttled_writes_upper_threshold):
+            logger.info(
+                '{0} - Down scaling event detected. No action taken as there'
+                ' are still throttled writes'.format(table_name))
         else:
             if consumed_calculated_provisioning:
                 if decrease_consumed_writes_unit == 'percent':


### PR DESCRIPTION
…rite requests.

Please integrate this commit into the main project. It solves the following issue:

The dynamic DynamoDB scaler considers the used write capacity and the number of throttled writes when scaling up. This works fine.
But when scaling down it only considers the used write capacity - but ignores the throttled writes. This made the scaler scaling capacity up and down continuously when the used write capacity collapsed due to throttled writes.

So I added a little check that prevents it from scaling down as long as there are still throttled writes.

Cheers
Robert