### PR TITLE
Check for autoscale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ nosetests.xml
 node_modules
 
 .ropeproject
+.idea

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Features in short
 - Gives you control over how much reads and writes you want to scale up and down with
 - Dynamic DynamoDB has support for max and min limits so that you always knows how much money you spend at most and how much capacity you can be guaranteed
 - Support for circuit breaker API call. If your service is experiencing disturbances, Dynamic DynamoDB will not scale down your DynamoDB tables
+- Check to prevent dynamid-dynamodb from fighting with the auto-scale API and provisioning tables that are already autoscaling
 
 Documentation
 -------------
@@ -72,6 +73,7 @@ If you want to set up a separate IAM user for Dynamic DynamoDB, then you need to
 * `dynamodb:ListTables`
 * `dynamodb:UpdateTable`
 * `sns:Publish` (used by the SNS notifications feature)
+* `application-autoscaling:DescribeScalingPolicies` (used to prevent dynamic-dynamodb from changing provisioning on an autoscaled table)
 
 An example policy could look like this:
 
@@ -84,6 +86,7 @@ An example policy could look like this:
             "dynamodb:DescribeTable",
             "dynamodb:ListTables",
             "dynamodb:UpdateTable",
+            "application-autoscaling:DescribeScalingPolicies",
             "cloudwatch:GetMetricStatistics"
           ],
           "Resource": [

--- a/dynamic_dynamodb/aws/dynamodb.py
+++ b/dynamic_dynamodb/aws/dynamodb.py
@@ -118,8 +118,6 @@ def get_dynamodb_table_scaling_policy_enabled(table_name):
         return True
     elif not scaling_policy['ScalingPolicies']:
         return False
-    else:
-        logger.error('Something went wrong trying to determine if {} has an autoscale policy enabled'.format(table_name))
 
 
 def get_provisioned_gsi_read_units(table_name, gsi_name):
@@ -313,7 +311,7 @@ def update_table_provisioning(
             writes = current_writes
 
         # Return if we do not need to scale at all
-        if (reads == current_reads and writes == current_writes):
+        if reads == current_reads and writes == current_writes:
             logger.info(
                 '{0} - No need to scale up reads nor writes'.format(
                     table_name))

--- a/dynamic_dynamodb/aws/dynamodb.py
+++ b/dynamic_dynamodb/aws/dynamodb.py
@@ -296,7 +296,7 @@ def update_table_provisioning(
     table = get_table(table_name)
     # If table has autoscale enabled, don't touch it, log a warning.
     if get_dynamodb_table_scaling_policy_enabled(table_name):
-        logger.warn('Table {} has autoscale enabled.'.format(table_name))
+        logger.warning('Table {} has autoscale enabled. Canceling provision change.'.format(table_name))
         return
 
     current_reads = int(get_provisioned_table_read_units(table_name))

--- a/dynamic_dynamodb/aws/dynamodb.py
+++ b/dynamic_dynamodb/aws/dynamodb.py
@@ -478,7 +478,8 @@ def update_gsi_provisioning(
     """
     # If the index has autoscale enabled, then we should skip it
     if get_dynamodb_gsi_scaling_policy_enabled(table_name, gsi_name):
-        logger.warning('Table {} - GSI {} has autoscale enabled. Canceling provision change.'.format(table_name))
+        logger.warning('Table {} - GSI {} has autoscale enabled. Canceling provision change.'.format(table_name,
+                                                                                                     gsi_name))
         return
 
     current_reads = int(get_provisioned_gsi_read_units(table_name, gsi_name))

--- a/dynamic_dynamodb/aws/dynamodb.py
+++ b/dynamic_dynamodb/aws/dynamodb.py
@@ -8,6 +8,7 @@ import datetime
 from boto import dynamodb2
 from boto.dynamodb2.table import Table
 from boto.exception import DynamoDBResponseError, JSONResponseError
+import boto3
 
 from dynamic_dynamodb.log_handler import LOGGER as logger
 from dynamic_dynamodb.config_handler import (
@@ -102,6 +103,23 @@ def get_gsi_status(table_name, gsi_name):
     for gsi in desc[u'Table'][u'GlobalSecondaryIndexes']:
         if gsi[u'IndexName'] == gsi_name:
             return gsi[u'IndexStatus']
+
+
+def get_dynamodb_table_scaling_policy_enabled(table_name):
+    """
+    Returns boolean value of if autoscale is enabled or not for a given table
+    :param table_name: 
+    :return: Bool - True if enabled, false if not.
+    """
+    scaling_policy = AUTO_SCALE_CLIENT.describe_scaling_policies(
+                                                                ServiceNamespace='dynamodb',
+                                                                ResourceId='table/{}'.format(table_name))
+    if scaling_policy['ScalingPolicies']:
+        return True
+    elif not scaling_policy['ScalingPolicies']:
+        return False
+    else:
+        logger.error('Something went wrong trying to determine if {} has an autoscale policy enabled'.format(table_name))
 
 
 def get_provisioned_gsi_read_units(table_name, gsi_name):
@@ -276,6 +294,11 @@ def update_table_provisioning(
     :param retry_with_only_increase: Set to True to ensure only increases
     """
     table = get_table(table_name)
+    # If table has autoscale enabled, don't touch it, log a warning.
+    if get_dynamodb_table_scaling_policy_enabled(table_name):
+        logger.warn('Table {} has autoscale enabled.'.format(table_name))
+        return
+
     current_reads = int(get_provisioned_table_read_units(table_name))
     current_writes = int(get_provisioned_table_write_units(table_name))
 
@@ -290,7 +313,7 @@ def update_table_provisioning(
             writes = current_writes
 
         # Return if we do not need to scale at all
-        if reads == current_reads and writes == current_writes:
+        if (reads == current_reads and writes == current_writes):
             logger.info(
                 '{0} - No need to scale up reads nor writes'.format(
                     table_name))
@@ -616,6 +639,45 @@ def table_gsis(table_name):
 
     return []
 
+def __get_connection_autoscale(retries=3):
+    """ Ensure connection to AutoScale
+
+        :type retries: int
+        :param retries: Number of times to retry to connect to AutoScale
+        """
+    connected = False
+    region = get_global_option('region')
+
+    while not connected:
+        if (get_global_option('aws_access_key_id') and
+                get_global_option('aws_secret_access_key')):
+            logger.debug(
+                'Authenticating to ApplicationAutoScaling using '
+                'credentials in configuration file')
+            connection = boto3.client('application-autoscaling',
+                                      region_name=region,
+                                      aws_access_key_id=get_global_option('aws_access_key_id'),
+                                      aws_secret_access_key=get_global_option('aws_secret_access_key'))
+        else:
+            logger.debug(
+                'Authenticating using boto3\'s authentication handler')
+            connection = boto3.client('application-autoscaling', region_name=region)
+
+        if not connection:
+            if retries == 0:
+                logger.error('Failed to connect to ApplicationAutoScaling. Giving up.')
+                raise
+            else:
+                logger.error(
+                    'Failed to connect to ApplicationAutoScaling. Retrying in 5 seconds')
+                retries -= 1
+                time.sleep(5)
+        else:
+            connected = True
+            logger.debug('Connected to ApplicationAutoScaling in {0}'.format(region))
+
+    return connection
+
 
 def __get_connection_dynamodb(retries=3):
     """ Ensure connection to DynamoDB
@@ -723,3 +785,4 @@ def __is_table_maintenance_window(table_name, maintenance_windows):
     return False
 
 DYNAMODB_CONNECTION = __get_connection_dynamodb()
+AUTO_SCALE_CLIENT = __get_connection_autoscale()


### PR DESCRIPTION
The idea here is to let AWS AutoScale win in a contest between dynamicDynamoDB and AWS Autoscale.

Our particular org is moving away from Dynamic-DynamoDB, and this change reflects that. Tables with autoscale policies will react faster in our experience. Others could benefit from this change, and in my testing I haven't seen this affect default behavior outside of the intended "don't poke auto-scaled tables."

I tried to follow patterns that I saw in the files I edited, and put the check just before the provision change to keep dynamic-dynamodb from hitting the AutoScale API a lot.